### PR TITLE
Command-line params plus iteration

### DIFF
--- a/imaging/iter_cosmics.py
+++ b/imaging/iter_cosmics.py
@@ -1,0 +1,19 @@
+# iterate run_cosmics.py with different parameters 
+
+import subprocess
+
+#python run_cosmics.py --files ../../temp/fits/u2mi0102t_c0m.fits -i 1 -sc 3.0 -rn 5.0
+
+for iters in range(0,10):
+	rn=2.5
+	while rn <= 7.5:
+		subprocess.call(['python', 'run_cosmics.py', '--files', 
+						'../../temp/fits/u2mi0102t_c0m.fits',
+						'-i', str(iters), '-sc', '3.0', '-rn', str(rn)]);
+		rn=rn+1;
+	sc=0.5
+	while sc <= 6.0:
+		subprocess.call(['python', 'run_cosmics.py', '--files', 
+					'../../temp/fits/u2mi0102t_c0m.fits',
+					'-i', str(iters), '-sc', str(sc), '-rn', '5.0']);
+		sc=sc+1

--- a/imaging/iter_cosmics.py
+++ b/imaging/iter_cosmics.py
@@ -2,18 +2,18 @@
 
 import subprocess
 
-#python run_cosmics.py --files ../../temp/fits/u2mi0102t_c0m.fits -i 1 -sc 3.0 -rn 5.0
+#python run_cosmics.py --files ../../temp/fits/u2mi0102t_c0m.fits -i 1 -sigmaclip 3.0 -readnoise 5.0
 
 for iters in range(0,10):
-	rn=2.5
-	while rn <= 7.5:
+	readnoise = 2.5
+	while readnoise <= 7.5:
 		subprocess.call(['python', 'run_cosmics.py', '--files', 
 						'../../temp/fits/u2mi0102t_c0m.fits',
-						'-i', str(iters), '-sc', '3.0', '-rn', str(rn)]);
-		rn=rn+1;
-	sc=0.5
-	while sc <= 6.0:
+						'-i', str(iters), '-sigmaclip', '3.0', '-readnoise', str(readnoise)]);
+		readnoise = readnoise + 1;
+	sigmaclip = 0.5
+	while sigmaclip <= 6.0:
 		subprocess.call(['python', 'run_cosmics.py', '--files', 
 					'../../temp/fits/u2mi0102t_c0m.fits',
-					'-i', str(iters), '-sc', str(sc), '-rn', '5.0']);
-		sc=sc+1
+					'-i', str(iters), '-sigmaclip', str(sigmaclip), '-readnoise', '5.0']);
+		sigmaclip = sigmaclip+1

--- a/imaging/iter_cosmics.py
+++ b/imaging/iter_cosmics.py
@@ -1,8 +1,9 @@
-# iterate run_cosmics.py with different parameters 
+'''
+iterate run_cosmics.py with different parameters 
+'''
 
 import subprocess
 
-#python run_cosmics.py --files ../../temp/fits/u2mi0102t_c0m.fits -i 1 -sigmaclip 3.0 -readnoise 5.0
 
 for iters in range(0,10):
 	readnoise = 2.5

--- a/imaging/run_cosmics.py
+++ b/imaging/run_cosmics.py
@@ -39,13 +39,12 @@ def make_c1m_link(filename):
 
 # -----------------------------------------------------------------------------
 
-def run_cosmics(filename):
+def run_cosmics(filename, iters, rn, sc):
     '''
     The main controller.
     '''
     
-    output = filename.split('_')[0] + "_cr_" + filename.split('_')[1]
-
+    output = filename.split('_')[0] + "_cr_" + str(iters) + "iters_" + str(rn)  + "rn_" + str(sc) + "sc_" + filename.split('_')[1]
     # Assert the input file exists
     error = filename + ' input for run_cosmics in '
     error += 'run_cosmics.py does not exist.'
@@ -85,8 +84,8 @@ def run_cosmics(filename):
                         array, 
                         pssl = 0.0, 
                         gain = 1.0, 
-                        readnoise = 5.0,
-                        sigclip = 3.0, 
+                        readnoise = rn, #5.0
+                        sigclip = sc, #3.0
                         sigfrac = 0.01, 
                         objlim = 4.0,
                         satlevel = 4095.0,
@@ -98,15 +97,15 @@ def run_cosmics(filename):
                         array, 
                         pssl = 0.0, 
                         gain=1.0, 
-                        readnoise=5.0,
-                        sigclip = 2.5, 
+                        readnoise = rn, #5.0
+                        sigclip = sc, #2.5 
                         sigfrac = 0.001, 
                         objlim = 5.0,
                         satlevel = 4095.0, 
                         verbose = True)
 
             # Run the full artillery
-            c.run(maxiter = 7)
+            c.run(maxiter = iters)
 
             # Write the cleaned image into a new FITS file
             # conserving the original header :
@@ -144,11 +143,29 @@ def parse_args():
         required = True,
         help = 'Search string for the fits files you want to ingest.\
             e.g. "dir/*.fits"')
+    parser.add_argument(
+        '-rn', 
+        '-readnoise',
+        required = True,
+        help = 'Set readnoise, default = 5.0')
+    parser.add_argument(
+        '-sc', 
+        '-sigclip',
+        required = True,
+        help = 'Set sigclip, default = 3.0')
+    parser.add_argument(
+        '-i',
+        '-iter', 
+        required = True,
+        help = 'Set max iteration, default = 7')
     args = parser.parse_args() 
     return args
 
 if __name__ == '__main__':
     args = parse_args()
     file_list = get_file_list(args.files)
+    iters = int(args.i)
+    rn = float(args.rn)
+    sc = float(args.sc) 
     for filename in file_list:
-        run_cosmics(filename)
+         run_cosmics(filename, iters, rn, sc)

--- a/imaging/run_cosmics.py
+++ b/imaging/run_cosmics.py
@@ -39,12 +39,12 @@ def make_c1m_link(filename):
 
 # -----------------------------------------------------------------------------
 
-def run_cosmics(filename, iters, rn, sc):
+def run_cosmics(filename, iters, readnoise, sigmaclip):
     '''
     The main controller.
     '''
     
-    output = filename.split('_')[0] + "_cr_" + str(iters) + "iters_" + str(rn)  + "rn_" + str(sc) + "sc_" + filename.split('_')[1]
+    output = filename.split('_')[0] + "_cr_" + str(iters) + "iters_" + str(readnoise)  + "rn_" + str(sigmaclip) + "sc_" + filename.split('_')[1]
     # Assert the input file exists
     error = filename + ' input for run_cosmics in '
     error += 'run_cosmics.py does not exist.'
@@ -84,8 +84,8 @@ def run_cosmics(filename, iters, rn, sc):
                         array, 
                         pssl = 0.0, 
                         gain = 1.0, 
-                        readnoise = rn, #5.0
-                        sigclip = sc, #3.0
+                        readnoise = readnoise, #5.0
+                        sigclip = sigmaclip, #3.0
                         sigfrac = 0.01, 
                         objlim = 4.0,
                         satlevel = 4095.0,
@@ -97,8 +97,8 @@ def run_cosmics(filename, iters, rn, sc):
                         array, 
                         pssl = 0.0, 
                         gain=1.0, 
-                        readnoise = rn, #5.0
-                        sigclip = sc, #2.5 
+                        readnoise = readnoise, #5.0
+                        sigclip = sigmaclip, #2.5 
                         sigfrac = 0.001, 
                         objlim = 5.0,
                         satlevel = 4095.0, 
@@ -144,15 +144,15 @@ def parse_args():
         help = 'Search string for the fits files you want to ingest.\
             e.g. "dir/*.fits"')
     parser.add_argument(
-        '-rn', 
         '-readnoise',
+        '-rn', 
         required = True,
         help = 'Set readnoise, default = 5.0')
     parser.add_argument(
+        '-sigmaclip',
         '-sc', 
-        '-sigclip',
         required = True,
-        help = 'Set sigclip, default = 3.0')
+        help = 'Set sigmaclip, default = 3.0')
     parser.add_argument(
         '-i',
         '-iter', 
@@ -165,7 +165,7 @@ if __name__ == '__main__':
     args = parse_args()
     file_list = get_file_list(args.files)
     iters = int(args.i)
-    rn = float(args.rn)
-    sc = float(args.sc) 
+    readnoise = float(args.readnoise)
+    sigmaclip = float(args.sigmaclip) 
     for filename in file_list:
-         run_cosmics(filename, iters, rn, sc)
+         run_cosmics(filename, iters, readnoise, sigmaclip)


### PR DESCRIPTION
Modified `run_cosmics.py` : Now accepts (and requires) command-line parameters for `readnoise`, `iter` and `sigclip`.
File names generated for the output now include the parameters used to distinguish them.

Added script `iter_cosmics.py` : Runs `run_cosmics.py` with different values for iterations (currently set at 0-10) , readnoise (currently 2.5-7.5), and sigclip (currently 0.5 - 6.0). Currently uses file `u2mi0102t_c0m.fits`

Both scripts have been tested.

I am going to go through these scripts again to make sure it is going to do what we want and then am gonna run it for the above settings (should be around 250 images) before I leave at 5. If you could take a look before then and provide comments on any changes if necessary then that would be great. If not will look at the images generated tomorrow morning and let you know and we can tweak params from there.
