### PR TITLE
Adding specifying `cosmicx` parameters in `.yaml` files.

### DIFF
--- a/cosmicx_cfg/HRC_params.yaml
+++ b/cosmicx_cfg/HRC_params.yaml
@@ -1,5 +1,5 @@
 1 : 
-    inmask : None
+    inmask : null
     outmaskfile : ""
     pssl : 0.0
     gain : 1.0

--- a/cosmicx_cfg/HRC_params.yaml
+++ b/cosmicx_cfg/HRC_params.yaml
@@ -1,0 +1,14 @@
+1 : 
+    inmask : None
+    outmaskfile : ""
+    pssl : 0.0
+    gain : 1.0
+    readnoise : 1.0
+    sigclip : 5.0
+    sigfrac : 0.01
+    objlim : 4.0
+    satlevel : 4095.0
+    robust : False
+    verbose : True
+    niter : 4
+

--- a/cosmicx_cfg/IR_params.yaml
+++ b/cosmicx_cfg/IR_params.yaml
@@ -1,5 +1,5 @@
 1 : 
-    inmask : None
+    inmask : null
     outmaskfile : ""
     pssl : 0.0
     gain : 1.0

--- a/cosmicx_cfg/IR_params.yaml
+++ b/cosmicx_cfg/IR_params.yaml
@@ -1,0 +1,14 @@
+1 : 
+    inmask : None
+    outmaskfile : ""
+    pssl : 0.0
+    gain : 1.0
+    readnoise : 1.0
+    sigclip : 5.0
+    sigfrac : 0.01
+    objlim : 4.0
+    satlevel : 4095.0
+    robust : False
+    verbose : True
+    niter : 4
+

--- a/cosmicx_cfg/SBC_params.yaml
+++ b/cosmicx_cfg/SBC_params.yaml
@@ -1,5 +1,5 @@
 1 : 
-    inmask : None
+    inmask : null
     outmaskfile : ""
     pssl : 0.0
     gain : 1.0

--- a/cosmicx_cfg/SBC_params.yaml
+++ b/cosmicx_cfg/SBC_params.yaml
@@ -1,0 +1,14 @@
+1 : 
+    inmask : None
+    outmaskfile : ""
+    pssl : 0.0
+    gain : 1.0
+    readnoise : 1.0
+    sigclip : 5.0
+    sigfrac : 0.01
+    objlim : 4.0
+    satlevel : 4095.0
+    robust : False
+    verbose : True
+    niter : 4
+

--- a/cosmicx_cfg/UVIS_params.yaml
+++ b/cosmicx_cfg/UVIS_params.yaml
@@ -1,5 +1,5 @@
 1 : 
-    inmask : None
+    inmask : null
     outmaskfile : ""
     pssl : 0.0
     gain : 1.0

--- a/cosmicx_cfg/UVIS_params.yaml
+++ b/cosmicx_cfg/UVIS_params.yaml
@@ -1,0 +1,14 @@
+1 : 
+    inmask : None
+    outmaskfile : ""
+    pssl : 0.0
+    gain : 1.0
+    readnoise : 1.0
+    sigclip : 5.0
+    sigfrac : 0.01
+    objlim : 4.0
+    satlevel : 4095.0
+    robust : False
+    verbose : True
+    niter : 4
+

--- a/cosmicx_cfg/WFC_params.yaml
+++ b/cosmicx_cfg/WFC_params.yaml
@@ -1,0 +1,27 @@
+1 : 
+    inmask : None
+    outmaskfile : ""
+    pssl : 0.0
+    gain : 1.0
+    readnoise : 1.0
+    sigclip : 5.0
+    sigfrac : 0.01
+    objlim : 4.0
+    satlevel : 4095.0
+    robust : False
+    verbose : True
+    niter : 4
+
+4 : 
+    inmask : None
+    outmaskfile : ""
+    pssl : 0.0
+    gain : 1.0
+    readnoise : 1.0
+    sigclip : 5.0
+    sigfrac : 0.01
+    objlim : 4.0
+    satlevel : 4095.0
+    robust : False
+    verbose : True
+    niter : 4

--- a/cosmicx_cfg/WFC_params.yaml
+++ b/cosmicx_cfg/WFC_params.yaml
@@ -1,5 +1,5 @@
 1 : 
-    inmask : None
+    inmask : null
     outmaskfile : ""
     pssl : 0.0
     gain : 1.0
@@ -13,7 +13,7 @@
     niter : 4
 
 4 : 
-    inmask : None
+    inmask : null
     outmaskfile : ""
     pssl : 0.0
     gain : 1.0

--- a/cosmicx_cfg/WFPC2_params.yaml
+++ b/cosmicx_cfg/WFPC2_params.yaml
@@ -1,0 +1,56 @@
+1 :
+    'inmask' : None
+    'outmaskfile' : ""
+    'pssl' : 0.0
+    'gain' : 1.0
+    'readnoise' : 1.0
+    'sigclip' : 5.0
+    'sigfrac' : 0.01
+    'objlim' : 4.0
+    'satlevel' : 4095.0
+    'robust' : False
+    'verbose' : True
+    'niter' : 4
+
+2 : 
+    'inmask' : None
+    'outmaskfile' : ""
+    'pssl' : 0.0
+    'gain' : 1.0
+    'readnoise' : 1.0
+    'sigclip' : 5.0
+    'sigfrac' : 0.001
+    'objlim' : 5.0
+    'satlevel' : 4095.0
+    'robust' : False
+    'verbose' : True
+    'niter' : 4
+
+3 : 
+    'inmask' : None
+    'outmaskfile' : ""
+    'pssl' : 0.0
+    'gain' : 1.0
+    'readnoise' : 1.0
+    'sigclip' : 5.0
+    'sigfrac' : 0.001
+    'objlim' : 5.0
+    'satlevel' : 4095.0
+    'robust' : False
+    'verbose' : True
+    'niter' : 4
+
+4 : 
+    'inmask' : None
+    'outmaskfile' : ""
+    'pssl' : 0.0
+    'gain' : 1.0
+    'readnoise' : 1.0
+    'sigclip' : 5.0
+    'sigfrac' : 0.001
+    'objlim' : 5.0
+    'satlevel' : 4095.0
+    'robust' : False
+    'verbose' : True
+    'niter' : 4
+

--- a/cosmicx_cfg/WFPC2_params.yaml
+++ b/cosmicx_cfg/WFPC2_params.yaml
@@ -1,5 +1,5 @@
 1 :
-    'inmask' : None
+    'inmask' : null
     'outmaskfile' : ""
     'pssl' : 0.0
     'gain' : 1.0
@@ -13,7 +13,7 @@
     'niter' : 4
 
 2 : 
-    'inmask' : None
+    'inmask' : null
     'outmaskfile' : ""
     'pssl' : 0.0
     'gain' : 1.0
@@ -27,7 +27,7 @@
     'niter' : 4
 
 3 : 
-    'inmask' : None
+    'inmask' : null
     'outmaskfile' : ""
     'pssl' : 0.0
     'gain' : 1.0
@@ -41,7 +41,7 @@
     'niter' : 4
 
 4 : 
-    'inmask' : None
+    'inmask' : null
     'outmaskfile' : ""
     'pssl' : 0.0
     'gain' : 1.0

--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -16,6 +16,7 @@ import sys
 from datetime import datetime
 from platform import architecture
 from stwcs import updatewcs
+from astropy.io import fits
 
 # Custom Packages
 from mtpipeline.imaging.run_cosmicx import run_cosmicx
@@ -38,6 +39,41 @@ def check_for_outputs(outputs):
         if not os.path.exists(item):
             return False
     return True
+
+# ----------------------------------------------------------------------------
+
+def get_metadata(filename):
+    """Retrieves the instrument and detector info from a FITS image's header.
+
+    Parameters:
+        filename: str
+            The path to and the filename of a FITS image.
+        
+    Returns:
+        (instrument, detector): tuple of either two strings or a string and 
+                                None
+            Possible instruments: 'WFPC2', 'WFC3', 'ACS' 
+            Possible detectors: 
+                None for WFPC2, 
+                'UVIS', 'IR' for WFC3
+                'SBC', 'HRC', 'WFC' for ACS
+
+    Outputs: nothing 
+
+    """
+
+    with fits.open(filename, mode='readonly') as HDUlist:
+
+        mainHDU = HDUlist[0]
+        instrument = mainHDU.header['instrume']
+        
+        #WFPC2 has no 'detector' keyword.
+        try:
+            detector = mainHDU.header['detector']
+        except:
+            detector = None
+
+    return instrument, detector
 
 # ----------------------------------------------------------------------------
 

--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -72,10 +72,10 @@ def get_metadata(filename):
         mainHDU = HDUlist[0]
         instrument = mainHDU.header['instrume']
         
-        #WFPC2 has no 'detector' keyword.
+        # Because WFPC2 has no 'detector' keyword:
         try:
             detector = mainHDU.header['detector']
-        except:
+        except KeyError:
             detector = instrument
 
     header_data = {'detector' : detector}
@@ -171,8 +171,8 @@ def imaging_pipeline(root_filename, output_path = None, cr_reject_switch=True,
             cosmicx_params = get_cosmicx_params(detector) 
             logging.info(cosmicx_params)
 
-            output_filname = output_file_dict['cr_reject_output'][1]
-            run_cosmicx(root_filename, outputfilename,cosmicx_params)
+            output_filename = output_file_dict['cr_reject_output'][1]
+            run_cosmicx(root_filename, output_filename,cosmicx_params)
             print 'Done running cr_reject'
             logging.info("Done running cr_reject")
     else:

--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -50,10 +50,10 @@ def get_metadata(filename):
             The path to and the filename of a FITS image.
         
     Returns:
-        (instrument, detector): tuple of either two strings or a string and 
-                                None
-            Possible instruments: 'WFPC2', 'WFC3', 'ACS' 
-            Possible detectors: 
+        instrument_detector: dictionary 
+            Has keys 'instrument' and 'detector' 
+            Possible 'instrument' values: 'WFPC2', 'WFC3', 'ACS' 
+            Possible 'detectors' values: 
                 None for WFPC2, 
                 'UVIS', 'IR' for WFC3
                 'SBC', 'HRC', 'WFC' for ACS
@@ -73,7 +73,10 @@ def get_metadata(filename):
         except:
             detector = None
 
-    return instrument, detector
+    instrument_detector = {'instrument' : instrument,
+                           'detector' : detector}
+
+    return instrument_detector
 
 # ----------------------------------------------------------------------------
 

--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -20,6 +20,7 @@ from astropy.io import fits
 
 # Custom Packages
 from mtpipeline.imaging.run_cosmicx import run_cosmicx
+from mtpipeline.imaging.run_cosmicx import get_cosmicx_params
 from mtpipeline.imaging.run_astrodrizzle import run_astrodrizzle
 from mtpipeline.imaging.run_trim import run_trim
 
@@ -43,18 +44,22 @@ def check_for_outputs(outputs):
 # ----------------------------------------------------------------------------
 
 def get_metadata(filename):
-    """Retrieves the instrument and detector info from a FITS image's header.
+    """Retrieves the image's detector, as well as the gain and 
+       readnoise, from a FITS image's header.
+    
+    NOTE: DOES NOT CURRENTLY RETRIEVE GAIN OR READNOISE. WILL BE IMPLEMENTED.
 
     Parameters:
         filename: str
             The path to and the filename of a FITS image.
         
     Returns:
-        instrument_detector: dictionary 
-            Has keys 'instrument' and 'detector' 
+        header_data: dict 
+            Has keys , 'detector','readnoise', and 'gain'
             Possible 'instrument' values: 'WFPC2', 'WFC3', 'ACS' 
             Possible 'detectors' values: 
-                None for WFPC2, 
+                'WFPC2' for WFPC2 (not technically correct, as WFPC2 FITS
+                images have no detector keyword, but accurate enough).
                 'UVIS', 'IR' for WFC3
                 'SBC', 'HRC', 'WFC' for ACS
 
@@ -71,12 +76,11 @@ def get_metadata(filename):
         try:
             detector = mainHDU.header['detector']
         except:
-            detector = None
+            detector = instrument
 
-    instrument_detector = {'instrument' : instrument,
-                           'detector' : detector}
+    header_data = {'detector' : detector}
 
-    return instrument_detector
+    return header_data
 
 # ----------------------------------------------------------------------------
 
@@ -161,7 +165,14 @@ def imaging_pipeline(root_filename, output_path = None, cr_reject_switch=True,
         else:
             logging.info("Running cr_reject")
             print 'Running cr_reject'
-            run_cosmicx(root_filename, output_file_dict['cr_reject_output'][1], 7)
+
+            header_data = get_metadata(root_filename)
+            detector = header_data['detector']
+            cosmicx_params = get_cosmicx_params(detector) 
+            logging.info(cosmicx_params)
+
+            output_filname = output_file_dict['cr_reject_output'][1]
+            run_cosmicx(root_filename, outputfilename,cosmicx_params)
             print 'Done running cr_reject'
             logging.info("Done running cr_reject")
     else:

--- a/mtpipeline/imaging/lacosmicx.py
+++ b/mtpipeline/imaging/lacosmicx.py
@@ -9,13 +9,11 @@ def run(inmat,inmask=None,outmaskfile="",sigclip=3.0,objlim=5.0,sigfrac=0.1,satl
     # .... Check arguments, double NumPy matrices?
     test=numpy.zeros((2,2)) # create a NumPy matrix as a test object to check matin
     typetest= type(test) # get its type  
-    print 'hello'
     if type(inmat) != typetest:
         raise TypeError('In inmat, matrix argument is not *NumPy* array')
     if inmask is None:
         inmask=numpy.zeros(inmat.shape)
     if type(inmask) != typetest:
-        print 'hello5'
         raise TypeError('In inmask, matrix argument is not *NumPy* array')
     this_shape=inmat.shape
     nx=this_shape[1]

--- a/mtpipeline/imaging/lacosmicx.py
+++ b/mtpipeline/imaging/lacosmicx.py
@@ -9,12 +9,14 @@ def run(inmat,inmask=None,outmaskfile="",sigclip=3.0,objlim=5.0,sigfrac=0.1,satl
     # .... Check arguments, double NumPy matrices?
     test=numpy.zeros((2,2)) # create a NumPy matrix as a test object to check matin
     typetest= type(test) # get its type  
+    print 'hello'
     if type(inmat) != typetest:
-        raise 'In inmat, matrix argument is not *NumPy* array'
+        raise TypeError('In inmat, matrix argument is not *NumPy* array')
     if inmask is None:
         inmask=numpy.zeros(inmat.shape)
     if type(inmask) != typetest:
-        raise 'In inmask, matrix argument is not *NumPy* array'
+        print 'hello5'
+        raise TypeError('In inmask, matrix argument is not *NumPy* array')
     this_shape=inmat.shape
     nx=this_shape[1]
     ny=this_shape[0]

--- a/mtpipeline/imaging/run_cosmicx.py
+++ b/mtpipeline/imaging/run_cosmicx.py
@@ -120,14 +120,15 @@ def run_cosmicx(filename, output, cosmicx_params):
         
         for key in cosmicx_params:
             
-            extension_params = cosmicx_params[key]
+            params = cosmicx_params[key]
             HDU = HDUlist[key]
 
             # It's possible some of the SCI extensions might not have data,
-            # as subsets of the CCD are sometimes used.
-            try:
+            # as subsets of the CCD are sometimes used, and these extensions
+            # are empty.
+            try: 
                 array = HDU.data
-            except:
+            except AttributeError: 
                 continue
 
             cleanarray = lacosmicx.run(array,

--- a/mtpipeline/imaging/run_cosmicx.py
+++ b/mtpipeline/imaging/run_cosmicx.py
@@ -4,7 +4,9 @@
 """
 
 import os
+import inspect
 import glob
+import yaml
 
 import lacosmicx
 from astropy.io import fits
@@ -31,8 +33,54 @@ def get_file_list(search_string):
     file_list = glob.glob(search_string)
     return file_list
 
+# -----------------------------------------------------------------------------
 
-def run_cosmicx(filename, output, iters):
+def get_cosmicx_params(detector):
+    """ Accesses the cosmicx configure file and returns the parameters.
+    
+    Parameters:
+        instrument: string
+            The intrument for the image. Can be 'WFPC2', 'WFC3', 'ACS'
+        detector: string
+            The detector aboard the instrument. Can be:
+                None for WFPC2, 
+                'UVIS', 'IR' for WFC3
+                'SBC', 'HRC', 'WFC' for ACS
+
+    Returns:
+        cosmicx_params: dict
+            A list of dictionaries, with one dictionary for each FITS 
+            extension. Each dictionary has the cosmicx parameters appropriate
+            for that extension. If the extension is not a science extension,
+            the list has None, instead of a dictionary, for that extension.
+
+    """
+
+
+
+    detector_config = { 'WFPC2' : "WFPC2_params.yaml",
+                        'HRC' : "HRC_params.yaml",
+                        'SBC' : "SBC_params.yaml",
+                        'WFC' : "WFC_params.yaml",
+                        'UVIS' : "UVIS_params.yaml",
+                        'IR' : "IR_params.yaml" }
+
+
+    # os.path.dirname is called three times to move up three directories
+    # from this file, to reach to where the cosmicx_cfg directory is located.
+    param_path = os.path.dirname(os.path.dirname(os.path.dirname(
+                 os.path.abspath(inspect.getfile(inspect.currentframe())))))
+
+    param_path = os.path.join(param_path,'cosmicx_cfg')
+    param_path = os.path.join(param_path,detector_config[detector])
+
+    cosmicx_params = yaml.load(open(param_path))
+    return cosmicx_params 
+
+# -----------------------------------------------------------------------------
+
+
+def run_cosmicx(filename, output, cosmicx_params):
     """ Driver to run lacosmicx on multi-extension WFPC2 FITS files.
 
     An equivalent to the run_cosmics function in run_cosmiscs.py,
@@ -69,42 +117,32 @@ def run_cosmicx(filename, output, iters):
         os.remove(output)
 
     with fits.open(filename, mode='readonly') as HDUlist:
+        
+        for key in cosmicx_params:
+            
+            extension_params = cosmicx_params[key]
+            HDU = HDUlist[key]
 
-        # Leave the first HDU untouched, process the remaining chip
-        # extensions
-        for ext in range(1, len(HDUlist)):
+            # It's possible some of the SCI extensions might not have data,
+            # as subsets of the CCD are sometimes used.
+            try:
+                array = HDU.data
+            except:
+                continue
 
-            HDU = HDUlist[ext]
-            array = HDU.data
-
-            if ext == 1:
-                cleanarray = lacosmicx.run(array,
-                        inmask=None,
-                        outmaskfile="",
-                        pssl=0.0,
-                        gain=1.0,
-                        readnoise=1.0,
-                        sigclip=5.0, #3.0 -> 5.0
-                        sigfrac=0.01,
-                        objlim=4.0,
-                        satlevel=4095.0,
-                        robust=False,
-                        verbose=True,
-                        niter=iters)
-
-            elif ext in [2, 3, 4]:
-                cleanarray = lacosmicx.run(array,
-                        inmask=None,
-                        outmaskfile="",
-                        pssl=0.0,
-                        gain=1.0,
-                        readnoise=1.0,
-                        sigclip=5.0, #2.5 -> 5.0
-                        sigfrac=0.001,
-                        objlim=5.0,
-                        satlevel=4095.0,
-                        verbose=True,
-                        niter=iters)
+            cleanarray = lacosmicx.run(array,
+                       inmask=params['inmask'],
+                       outmaskfile=params['outmaskfile'],
+                       pssl=params['pssl'],
+                       gain=params['gain'],
+                       readnoise=params['readnoise'],
+                       sigclip=params['sigclip'],
+                       sigfrac=params['sigfrac'],
+                       objlim=params['objlim'],
+                       satlevel=params['satlevel'],
+                       robust=params['robust'],
+                       verbose=params['verbose'],
+                       niter=params['niter'] )
 
             HDU.data = cleanarray
 
@@ -112,6 +150,8 @@ def run_cosmicx(filename, output, iters):
 
     # Create the symbolic link
     make_c1m_link(os.path.abspath(filename))
+
+# -----------------------------------------------------------------------------
 
 def make_c1m_link(filename):
     """ Create a link to a c1m.fits that matches the cosmic ray rejected

--- a/template_settings.yaml
+++ b/template_settings.yaml
@@ -2,8 +2,8 @@
 ## Uncomment anything with a single # and modify the values for you setup.
 
 ## Database Settings
-##db_connection: mysql+pymysql://root:user@localhost/mtpipeline
-#db_echo: False
+db_connection: mysql+pymysql://root:user@localhost/mtpipeline
+db_echo: False
 
 ## Email Settings
 #email_switch: False

--- a/template_settings.yaml
+++ b/template_settings.yaml
@@ -1,20 +1,22 @@
 ## This is a template settings.yaml file. Rename a copy of this file to settings.yaml. 
 ## Uncomment anything with a single # and modify the values for you setup.
 
-# Database Settings
-db_connection: mysql+pymysql://root:user@localhost/mtpipeline
-db_echo: False
+## Database Settings
+##db_connection: mysql+pymysql://root:user@localhost/mtpipeline
+#db_echo: False
 
-# Email Settings
-email_switch: False
-contact_email: youremail@domain.com
+## Email Settings
+#email_switch: False
+#contact_email: youremail@domain.com
+
 # File System Settings
 #acs_input_path: /absolute/path/to/files
 #acs_output_path: /absolute/path/to/files
 #wfc3_input_path: /absolute/path/to/files
 #wfc3_output_path: /absolute/path/to/files
-wfpc2_input_path: /absolute/path/to/files
-wfpc2_output_path: /absolute/path/to/files
-logging_path: /absolute/path/to/files
-# Number of Cores
+#wfpc2_input_path: /absolute/path/to/files
+#wfpc2_output_path: /absolute/path/to/files
+#logging_path: /absolute/path/to/files
+
+## Number of Cores
 #num_cores: 


### PR DESCRIPTION
In the `metadata` branch, `cosmicx` parameters for each detector (WFPC2, UVIS, IR, WFC, HRC, SBC) can now be specified in separate `.yaml` files, inside a new directory `MTPipeline/cosmicx_cfg`. 

To support this, two new functions have been added. 

`get_metadata()` has been added to `run_imaging_pipeline.py`. It's job is to extract all information from the headers of our input `fits` files, so that we can configure the pipeline to those files needs. At the moment, the only information it returns (as a dictionary, with a single key and value) is the detector. However, we also might want to be able to pass the readnoise and gain of the files to `cosmicx`, so we may eventually add that capability once Ticket #115 has been resolved. Additional information might be needed for the `astrodrizzle` step. At the moment, however, `get_metadata()` is only called when doing the CR rejection step, so its position in `run_imaging_pipeline` will need to be changed when what it returns is useful for the other steps.

`get_cosmicx_params()` has been added to `run_cosmicx.py`. Its job is to use `PyYaml` to read in the appropriate `cosmicx` configuration file for a given detector. The keys of this dictionary are integers, corresponding to individual FITS extensions. The entires for each integer key are themselves dictionaries, which contain the `cosmicx` parameters appropriate for that extension.
