### PR TITLE
Merge add_metadata and filename_handling

### DIFF
--- a/mtpipeline/imaging/run_cosmicx.py
+++ b/mtpipeline/imaging/run_cosmicx.py
@@ -168,7 +168,7 @@ def make_c1m_link(filename):
         A symbolic link to 'filename'
     """
 
-    if filename[-8:] == 'c0m.fits'
+    if filename[-8:] == 'c0m.fits':
         src = filename.replace('_c0m.fits', '_c1m.fits')
         dst = src.replace('_c1m.fits', '_cr_c1m.fits')
         query = os.path.islink(dst)

--- a/mtpipeline/imaging/run_cosmicx.py
+++ b/mtpipeline/imaging/run_cosmicx.py
@@ -107,7 +107,7 @@ def run_cosmicx(filename, output, cosmicx_params):
     """
 
     # Assert the input file exists
-    error = filename + ' input for run_cosmics in '
+    error = filename + ' input for run_cosmicx in '
     error += 'run_cosmics.py does not exist.'
     assert os.access(filename, os.F_OK), error
 
@@ -156,7 +156,7 @@ def run_cosmicx(filename, output, cosmicx_params):
 
 def make_c1m_link(filename):
     """ Create a link to a c1m.fits that matches the cosmic ray rejected
-    naming scheme.
+    naming scheme. This is only done for WFPC2 data (which ends in _c0m.fits)
 
     Parameters:
         filename: string
@@ -168,11 +168,11 @@ def make_c1m_link(filename):
         A symbolic link to 'filename'
     """
 
-    error = filename + ' does not end in "c0m.fits".'
-    assert filename[-8:] == 'c0m.fits', error
-    src = filename.replace('_c0m.fits', '_c1m.fits')
-    dst = src.replace('_c1m.fits', '_cr_c1m.fits')
-    query = os.path.islink(dst)
-    if query == True:
-        os.remove(dst)
-    os.symlink(src, dst)
+    if filename[-8:] == 'c0m.fits'
+        src = filename.replace('_c0m.fits', '_c1m.fits')
+        dst = src.replace('_c1m.fits', '_cr_c1m.fits')
+        query = os.path.islink(dst)
+
+        if query == True:
+            os.remove(dst)
+        os.symlink(src, dst)

--- a/scripts/production/run_imaging_pipeline.py
+++ b/scripts/production/run_imaging_pipeline.py
@@ -120,7 +120,7 @@ def run():
         logging.info(arg + ": " + str(args_list.__dict__[arg]))
     rootfile_list = glob.glob(args_list.filelist)
     rootfile_list = [filename for filename
-                     in filelist
+                     in rootfile_list
                      if '_cr_' not in filename
                      and ('_flt.fits' in filename or '_c0m.fits' in filename)]
     assert rootfile_list != [], 'empty rootfile_list in mtpipeline.py.'

--- a/scripts/production/run_imaging_pipeline.py
+++ b/scripts/production/run_imaging_pipeline.py
@@ -120,9 +120,9 @@ def run():
         logging.info(arg + ": " + str(args_list.__dict__[arg]))
     rootfile_list = glob.glob(args_list.filelist)
     rootfile_list = [filename for filename
-                     in rootfile_list
-                     if len(filename.split('/')[-1]) == 18
-                     and filename.split('/')[-1].split('_')[-1] == 'c0m.fits']
+                     in filelist
+                     if '_cr_' not in filename
+                     and ('_flt.fits' in filename or '_c0m.fits' in filename)]
     assert rootfile_list != [], 'empty rootfile_list in mtpipeline.py.'
     logging.info("Processing: {} files".format(len(rootfile_list)))
     logging.info("Number of Processes: {}".format(num_cores))


### PR DESCRIPTION
`add_metadata` contains the changes necessary so `cosmicx` gets the readnoise and gain from the FITS header, if those parameters are to found there. `filename_handling` has just a couple changes so that the pipeline can accept `_flt.fits` files in addition to `_c0m.fits` files. 

`filename_handling` appears to run successfully (up to Astrodrizzle) on inputs from all six detectors.
