### PR TITLE
Merge add_metadata into master

### DIFF
--- a/cosmicx_cfg/HRC_params.yaml
+++ b/cosmicx_cfg/HRC_params.yaml
@@ -2,12 +2,12 @@
     inmask : null
     outmaskfile : ""
     pssl : 0.0
-    gain : 1.0
-    readnoise : 1.0
-    sigclip : 5.0
+    gain : 4.7
+    readnoise : 2.0
+    sigclip : 15.0
     sigfrac : 0.01
     objlim : 4.0
-    satlevel : 4095.0
+    satlevel : 50000.0 
     robust : False
     verbose : True
     niter : 4

--- a/cosmicx_cfg/IR_params.yaml
+++ b/cosmicx_cfg/IR_params.yaml
@@ -4,10 +4,10 @@
     pssl : 0.0
     gain : 1.0
     readnoise : 1.0
-    sigclip : 5.0
+    sigclip : 2.0
     sigfrac : 0.01
     objlim : 4.0
-    satlevel : 4095.0
+    satlevel : 500.0
     robust : False
     verbose : True
     niter : 4

--- a/cosmicx_cfg/SBC_params.yaml
+++ b/cosmicx_cfg/SBC_params.yaml
@@ -4,10 +4,10 @@
     pssl : 0.0
     gain : 1.0
     readnoise : 1.0
-    sigclip : 5.0
+    sigclip : 3.0
     sigfrac : 0.01
     objlim : 4.0
-    satlevel : 4095.0
+    satlevel : 500.0
     robust : False
     verbose : True
     niter : 4

--- a/cosmicx_cfg/UVIS_params.yaml
+++ b/cosmicx_cfg/UVIS_params.yaml
@@ -4,11 +4,11 @@
     pssl : 0.0
     gain : 1.0
     readnoise : 1.0
-    sigclip : 5.0
+    sigclip : 9.0
     sigfrac : 0.01
     objlim : 4.0
-    satlevel : 4095.0
+    satlevel : 10000.0
     robust : False
     verbose : True
-    niter : 4
+    niter : 5
 

--- a/cosmicx_cfg/WFC_params.yaml
+++ b/cosmicx_cfg/WFC_params.yaml
@@ -7,10 +7,10 @@
     sigclip : 5.0
     sigfrac : 0.01
     objlim : 4.0
-    satlevel : 4095.0
+    satlevel : 12000.0
     robust : False
     verbose : True
-    niter : 4
+    niter : 2
 
 4 : 
     inmask : null
@@ -21,7 +21,7 @@
     sigclip : 5.0
     sigfrac : 0.01
     objlim : 4.0
-    satlevel : 4095.0
+    satlevel : 12000.0
     robust : False
     verbose : True
-    niter : 4
+    niter : 2

--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+
 
 '''
 This is the main module for the Moving Target Pipeline.
@@ -82,11 +82,9 @@ def get_metadata(filename):
         readnoise = None
 
         # For WFPC2, there is no readnoise information in the header.
+	# There is gain information, but it leads to bad CR rejection.
         # For ACS / SBC, there is no readnoise or gain information.
 	    # If None, we use the settings provided in the cfg files.
-
-        if instrument == 'WFPC2':
-            gain = mainHDU.header['atodgain']
         
         if detector != 'SBC' and instrument != 'WFPC2':
       	    gain = mainHDU.header['ccdgain']

--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -78,7 +78,28 @@ def get_metadata(filename):
         except KeyError:
             detector = instrument
 
-    header_data = {'detector' : detector}
+        # For WFPC2, there is no readnoise information in the header.
+        # For ACS / SBC, there is no readnoise or gain information.
+        gain = None
+        readnoise = None
+
+        # Find the gain.
+        if instrument == 'WFPC2':
+            gain = mainHDU.header['atodgain']
+        else:
+            gain = mainHDU.header['ccdgain']
+        
+        # Find the readnoise. 
+        if instrument != 'WFPC2' and instrument != 'SBC':
+            readnoise_a = mainHDU.header['readnsea']
+            readnoise_b = mainHDU.header['readnseb']
+            readnoise_c = mainHDU.header['readnsec']
+            readnoise_d = mainHDU.header['readnsed']
+            readnoise = max(readnoise_a, readnoise_b,readnoise_c,readnoise_d)
+
+    header_data = {'detector' : detector,
+                   'readnoise' : readnoise,
+                   'gain' : gain }
 
     return header_data
 

--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -78,20 +78,18 @@ def get_metadata(filename):
         except KeyError:
             detector = instrument
 
-        # For WFPC2, there is no readnoise information in the header.
-        # For ACS / SBC, there is no readnoise or gain information.
-	# If None, we'll provide the settings manually in the cfg files.
         gain = None
         readnoise = None
 
-        # Find the gain.
+        # For WFPC2, there is no readnoise information in the header.
+        # For ACS / SBC, there is no readnoise or gain information.
+	    # If None, we use the settings provided in the cfg files.
+
         if instrument == 'WFPC2':
             gain = mainHDU.header['atodgain']
-        else:
-            gain = mainHDU.header['ccdgain']
         
-        # Find the readnoise. 
-        if instrument != 'WFPC2' and instrument != 'SBC':
+        if detector != 'SBC' and instrument != 'WFPC2':
+      	    gain = mainHDU.header['ccdgain']
             readnoise_a = mainHDU.header['readnsea']
             readnoise_b = mainHDU.header['readnseb']
             readnoise_c = mainHDU.header['readnsec']

--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -80,6 +80,7 @@ def get_metadata(filename):
 
         # For WFPC2, there is no readnoise information in the header.
         # For ACS / SBC, there is no readnoise or gain information.
+	# If None, we'll provide the settings manually in the cfg files.
         gain = None
         readnoise = None
 
@@ -188,8 +189,7 @@ def imaging_pipeline(root_filename, output_path = None, cr_reject_switch=True,
             print 'Running cr_reject'
 
             header_data = get_metadata(root_filename)
-            detector = header_data['detector']
-            cosmicx_params = get_cosmicx_params(detector) 
+            cosmicx_params = get_cosmicx_params(header_data) 
             logging.info(cosmicx_params)
 
             output_filename = output_file_dict['cr_reject_output'][1]

--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -185,11 +185,12 @@ def imaging_pipeline(root_filename, output_path = None, cr_reject_switch=True,
             print 'Running cr_reject'
 
             header_data = get_metadata(root_filename)
+            detector = header_data['detector']
             cosmicx_params = get_cosmicx_params(header_data) 
             logging.info(cosmicx_params)
 
             output_filename = output_file_dict['cr_reject_output'][1]
-            run_cosmicx(root_filename, output_filename,cosmicx_params)
+            run_cosmicx(root_filename, output_filename,cosmicx_params,detector)
             print 'Done running cr_reject'
             logging.info("Done running cr_reject")
     else:

--- a/mtpipeline/imaging/run_cosmicx.py
+++ b/mtpipeline/imaging/run_cosmicx.py
@@ -35,17 +35,14 @@ def get_file_list(search_string):
 
 # -----------------------------------------------------------------------------
 
-def get_cosmicx_params(detector):
+def get_cosmicx_params(header_data):
     """ Accesses the cosmicx configure file and returns the parameters.
     
     Parameters:
         instrument: string
             The intrument for the image. Can be 'WFPC2', 'WFC3', 'ACS'
-        detector: string
-            The detector aboard the instrument. Can be:
-                None for WFPC2, 
-                'UVIS', 'IR' for WFC3
-                'SBC', 'HRC', 'WFC' for ACS
+        header_data: dictionary
+                Dictionary containing information from FITS header
 
     Returns:
         cosmicx_params: dict
@@ -57,7 +54,6 @@ def get_cosmicx_params(detector):
     """
 
 
-
     detector_config = { 'WFPC2' : "WFPC2_params.yaml",
                         'HRC' : "HRC_params.yaml",
                         'SBC' : "SBC_params.yaml",
@@ -65,16 +61,29 @@ def get_cosmicx_params(detector):
                         'UVIS' : "UVIS_params.yaml",
                         'IR' : "IR_params.yaml" }
 
+    detector = header_data["detector"]
+    readnoise = header_data["readnoise"]
+    gain = header_data["gain"]
+
+    # Load the configuration file for the proper detector:
+    config_file = detector_config[detector]
 
     # os.path.dirname is called three times to move up three directories
     # from this file, to reach to where the cosmicx_cfg directory is located.
     param_path = os.path.dirname(os.path.dirname(os.path.dirname(
                  os.path.abspath(inspect.getfile(inspect.currentframe())))))
-
     param_path = os.path.join(param_path,'cosmicx_cfg')
-    param_path = os.path.join(param_path,detector_config[detector])
+    param_path = os.path.join(param_path, config_file)
 
     cosmicx_params = yaml.load(open(param_path))
+
+    # If we have readnoise and gain from the FITS header, override the 
+    # manually specified values from the cfg file:
+    if readnoise:
+        cosmicx_params["readnoise"] = readnoise
+    if gain:
+        cosmicx_params["gain"] = gain
+
     return cosmicx_params 
 
 # -----------------------------------------------------------------------------

--- a/mtpipeline/imaging/run_cosmicx.py
+++ b/mtpipeline/imaging/run_cosmicx.py
@@ -168,7 +168,7 @@ def make_c1m_link(filename):
         A symbolic link to 'filename'
     """
 
-    if filename[-8:] == 'c0m.fits'
+    if filename[-8:] == 'c0m.fits':
         src = filename.replace('_c0m.fits', '_c1m.fits')
         dst = src.replace('_c1m.fits', '_cr_c1m.fits')
         query = os.path.islink(dst)

--- a/mtpipeline/imaging/run_cosmicx.py
+++ b/mtpipeline/imaging/run_cosmicx.py
@@ -87,16 +87,12 @@ def get_cosmicx_params(header_data):
         for extension_key in cosmicx_params:
             cosmicx_params[extension_key]["gain"] = gain
 
-    # Add the instrument into the params. Not needed for cosmicx, but needed
-    # for run_cosmicx to decide whether to run CR rejection at all.
-    cosmicx_params['detector'] = detector
-
     return cosmicx_params 
 
 # -----------------------------------------------------------------------------
 
 
-def run_cosmicx(filename, output, cosmicx_params):
+def run_cosmicx(filename, output, cosmicx_params, detector):
     """ Driver to run lacosmicx on multi-extension FITS files.
 
     An equivalent to the run_cosmics function in run_cosmiscs.py,
@@ -108,9 +104,13 @@ def run_cosmicx(filename, output, cosmicx_params):
             filename of input FITS file
         output: string
             desired filename of output, a cosmic ray rejected FITS file.
-        iters: int
-            number of iterations of the LACosmics algorithm to be
-            performed.
+        cosmicx_params: dictionary
+            a dictionary of dictionaries, with each entry dictionary
+            containing the cosmicx settings appropriate for a
+            particular FITS science extension.
+        detector: string
+            the detector used to take the FITS image. If SBC or IR,
+            cr rejection is not run.
 
     Returns: nothing
 
@@ -129,7 +129,6 @@ def run_cosmicx(filename, output, cosmicx_params):
 
     # If the file is taken by SBC or IR, do not cr reject, copy
     # the file with the output name, and return
-    detector = cosmicx_params['detector']
     if detector == 'SBC' or detector == 'IR':
         shutil.copyfile(filename,output)
         return

--- a/mtpipeline/imaging/run_cosmicx.py
+++ b/mtpipeline/imaging/run_cosmicx.py
@@ -148,6 +148,11 @@ def run_cosmicx(filename, output, cosmicx_params):
             except AttributeError: 
                 continue
 
+            # For a cleaner cr rejection, set all very negative pixels
+            # to 0. No significant science data should be lost, as these
+            # are already bad pixels.
+            array[array < -10.0] = 0.0
+
             cleanarray = lacosmicx.run(array,
                        inmask=params['inmask'],
                        outmaskfile=params['outmaskfile'],

--- a/mtpipeline/imaging/run_cosmicx.py
+++ b/mtpipeline/imaging/run_cosmicx.py
@@ -107,7 +107,7 @@ def run_cosmicx(filename, output, cosmicx_params):
     """
 
     # Assert the input file exists
-    error = filename + ' input for run_cosmics in '
+    error = filename + ' input for run_cosmicx in '
     error += 'run_cosmics.py does not exist.'
     assert os.access(filename, os.F_OK), error
 
@@ -156,7 +156,7 @@ def run_cosmicx(filename, output, cosmicx_params):
 
 def make_c1m_link(filename):
     """ Create a link to a c1m.fits that matches the cosmic ray rejected
-    naming scheme.
+    naming scheme. This is only done for WFPC2 data (which ends in _c0m.fits)
 
     Parameters:
         filename: string
@@ -168,11 +168,11 @@ def make_c1m_link(filename):
         A symbolic link to 'filename'
     """
 
-    error = filename + ' does not end in "c0m.fits".'
-    assert filename[-8:] == 'c0m.fits', error
-    src = filename.replace('_c0m.fits', '_c1m.fits')
-    dst = src.replace('_c1m.fits', '_cr_c1m.fits')
-    query = os.path.islink(dst)
-    if query == True:
-        os.remove(dst)
-    os.symlink(src, dst)
+    if filename[-8:] == 'c0m.fits'
+        src = filename.replace('_c0m.fits', '_c1m.fits')
+        dst = src.replace('_c1m.fits', '_cr_c1m.fits')
+        query = os.path.islink(dst)
+
+        if query == True:
+            os.remove(dst)
+        os.symlink(src, dst)

--- a/mtpipeline/imaging/run_cosmicx.py
+++ b/mtpipeline/imaging/run_cosmicx.py
@@ -80,9 +80,11 @@ def get_cosmicx_params(header_data):
     # If we have readnoise and gain from the FITS header, override the 
     # manually specified values from the cfg file:
     if readnoise:
-        cosmicx_params["readnoise"] = readnoise
+        for extension_key in cosmicx_params:
+            cosmicx_params[extension_key]["readnoise"] = readnoise
     if gain:
-        cosmicx_params["gain"] = gain
+        for extension_key in cosmicx_params:
+            cosmicx_params[extension_key]["gain"] = gain
 
     return cosmicx_params 
 

--- a/mtpipeline/imaging/run_cosmicx.py
+++ b/mtpipeline/imaging/run_cosmicx.py
@@ -132,11 +132,17 @@ def run_cosmicx(filename, output, cosmicx_params):
         for key in cosmicx_params:
             
             params = cosmicx_params[key]
-            HDU = HDUlist[key]
+
+            # It's possible there may not be the same number of SCI extensions
+            # in the image as we specify in the cfg files (WFC)
+            try: 
+                HDU = HDUlist[key]
+            except IndexError:
+                continue
 
             # It's possible some of the SCI extensions might not have data,
             # as subsets of the CCD are sometimes used, and these extensions
-            # are empty.
+            # are empty (UVIS)
             try: 
                 array = HDU.data
             except AttributeError: 

--- a/scripts/production/run_imaging_pipeline.py
+++ b/scripts/production/run_imaging_pipeline.py
@@ -120,7 +120,7 @@ def run():
         logging.info(arg + ": " + str(args_list.__dict__[arg]))
     rootfile_list = glob.glob(args_list.filelist)
     rootfile_list = [filename for filename
-                     in filelist
+                     in rootfile_list
                      if '_cr_' not in filename
                      and ('_flt.fits' in filename or '_c0m.fits' in filename)]
     assert rootfile_list != [], 'empty rootfile_list in mtpipeline.py.'

--- a/scripts/production/run_imaging_pipeline.py
+++ b/scripts/production/run_imaging_pipeline.py
@@ -120,9 +120,9 @@ def run():
         logging.info(arg + ": " + str(args_list.__dict__[arg]))
     rootfile_list = glob.glob(args_list.filelist)
     rootfile_list = [filename for filename
-                     in rootfile_list
-                     if len(filename.split('/')[-1]) == 18
-                     and filename.split('/')[-1].split('_')[-1] == 'c0m.fits']
+                     in filelist
+                     if '_cr_' not in filename
+                     and ('_flt.fits' in filename or '_c0m.fits' in filename)]
     assert rootfile_list != [], 'empty rootfile_list in mtpipeline.py.'
     logging.info("Processing: {} files".format(len(rootfile_list)))
     logging.info("Number of Processes: {}".format(num_cores))

--- a/scripts/production/run_imaging_pipeline.py
+++ b/scripts/production/run_imaging_pipeline.py
@@ -20,7 +20,8 @@ import logging
 import os
 import sys
 
-num_cores = mp.cpu_count() - 1
+# Setting this just to get the pipeline rolling.
+num_cores = 4
 
 def parse_args():
     """


### PR DESCRIPTION
`add_metadata` adds the remaining logic for the `master` branch to be able to run CR rejection on inputs from all six detectors. The pipeline now accepts `_flt.fits` files, in addition to `_c0m.fits` files. 

CR rejection is run on WFPC2, HRC, WFC, and UVIS using parameters acquired from files unique to each detector in `MTPipeline/cosmicx_cfg`. For HRC, WFC, and UVIS, the readnoise and gain are read from the image header files and supplant the readnoise and gain set in the configuration files. CR rejection is not run on IR or SBC images. We are confident that no CR rejection is needed for our IR data, and the same likely holds true for SBC (though not for the same reason). At the moment, the `cosmicx` parameter files for IR and SBC remain, but can in the future be removed (although this will require changes into `get_cosmicx_params`).
