### PR TITLE
Merging mast-names into Master

### DIFF
--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -98,7 +98,7 @@ def get_metadata(filename):
             readnoise_d = mainHDU.header['readnsed']
             readnoise = max(readnoise_a, readnoise_b,readnoise_c,readnoise_d)
 
-        if detector == 'WFPC2':
+        if instrument == 'WFPC2':
             try:
                 filtername = mainHDU.header['filtnam1']
             except: print "Failed to find filter keyword."

--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -104,21 +104,22 @@ def get_metadata(filename):
             except: print "Failed to find filter keyword."
         if instrument == 'WFC3':
             try:
-                fitername = mainHDU.header['filter']
+                filtername = mainHDU.header['filter']
             except: print "Failed to find filter keyword."
         if instrument == 'ACS':
             try:
                 filt1 = mainHDU.header['filter1']
                 filt2 = mainHDU.header['filter2']
-                if filt1[0] == 'F': filtname = filt1 
-                if filt2[0] == 'F': filtname = filt2 
+                if filt1[0] == 'F': filtername = filt1 
+                if filt2[0] == 'F': filtername = filt2 
             except: print "Failed to find filter keyword."
 
         try:
-            targname == mainHDU.header['targname']
+            targname = mainHDU.header['targname']
         except: print "Failed to find targname keyword."
 
-    header_data = {'detector' : detector,
+    header_data = {'instrument' : instrument,
+                   'detector' : detector,
                    'readnoise' : readnoise,
                    'gain' : gain,
                    'targname' : targname,
@@ -251,7 +252,6 @@ def make_output_file_dict(filename,header_data):
 
     instrument = header_data['instrument']
     detector = header_data['detector']
-
     if instrument == 'WFPC2':
         hardware = instrument.lower()
     else:
@@ -289,11 +289,11 @@ def make_output_file_dict(filename,header_data):
 
     # Drizzled outputs.
     # Cr rejected products are sci
-    filename = '_'.join([front,'sci']) + '.fits'
+    filename = '_'.join([front,'img']) + '.fits'
     filename = os.path.join(path,filename)
     output_file_dict['drizzle_output'].append(filename)
     # Non cr rejected products are img
-    filename = '_'.join([front,'img']) + '.fits'
+    filename = '_'.join([front,'sci']) + '.fits'
     filename = os.path.join(path,filename)
     output_file_dict['drizzle_output'].append(filename)
     # Only a single weight file
@@ -349,7 +349,10 @@ def imaging_pipeline(root_filename, output_path = None, cr_reject_switch=True,
             logging.info(cosmicx_params)
 
             output_filename = output_file_dict['cr_reject_output'][1]
-            run_cosmicx(root_filename, output_filename,cosmicx_params,detector)
+            run_cosmicx(root_filename, 
+                        output_filename,
+                        cosmicx_params,
+                        detector)
             print 'Done running cr_reject'
             logging.info("Done running cr_reject")
     else:
@@ -365,9 +368,10 @@ def imaging_pipeline(root_filename, output_path = None, cr_reject_switch=True,
         else:
             logging.info("Running Astrodrizzle")
             print 'Running Astrodrizzle'
-            for filename in  output_file_dict['cr_reject_output']:
+            for filename, output in zip(output_file_dict['cr_reject_output'],
+                                        output_file_dict['drizzle_output']):
                 updatewcs.updatewcs(filename)
-                run_astrodrizzle(filename, detector)
+                run_astrodrizzle(filename, output, detector)
             print 'Done running astrodrizzle'
             logging.info("Done running astrodrizzle")
     else:

--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -267,7 +267,7 @@ def make_output_file_dict(filename,header_data):
 
     ipsud_and_mtarg = ipsud + '-' + mtarg
 
-    filtername = header_data['filtername']
+    filtername = header_data['filtername'].lower()
 
     version = 'v' + str(SETTINGS['version'])
     version = version.replace('.','-')
@@ -307,16 +307,16 @@ def make_output_file_dict(filename,header_data):
 
     # PNG outputs.
     png = 'png/'
-    filename = png + '_'.join([front,'sci']) + '-linear.png'
+    filename = png + '_'.join([front,'sci']) + '-linscale.png'
     filename = os.path.join(path,filename)
     output_file_dict['png_output'].append(filename)
-    filename = png + '_'.join([front,'img']) + '-linear.png'
+    filename = png + '_'.join([front,'img']) + '-linscale.png'
     filename = os.path.join(path,filename)
     output_file_dict['png_output'].append(filename)
-    filename = png + '_'.join([front,'sci']) + '-log.png'
+    filename = png + '_'.join([front,'sci']) + '-logscale.png'
     filename = os.path.join(path,filename)
     output_file_dict['png_output'].append(filename)
-    filename = png + '_'.join([front,'img']) + '-log.png'
+    filename = png + '_'.join([front,'img']) + '-logscale.png'
     filename = os.path.join(path,filename)
     output_file_dict['png_output'].append(filename)
 

--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -258,17 +258,21 @@ def make_output_file_dict(filename,header_data):
         hardware = instrument.lower() + '-' + detector.lower()
 
     path, basename = os.path.split(filename)
+
+    #Get the 9-character alphanumeric identifier for the observation
     ipsud = basename.split('_')[0] 
 
     # Use string parsing to discern the target(s).
     mtarg = get_mtarg(header_data['targname'])
+
+    ipsud_and_mtarg = ipsud + '-' + mtarg
 
     filtername = header_data['filtername']
 
     version = 'v' + str(SETTINGS['version'])
     version = version.replace('.','-')
 
-    front = '_'.join([front,hardware,ipsud,mtarg,filtername,version])
+    front = '_'.join([front,hardware,ipsud_and_mtarg,filtername,version])
     
     # Initialize the dictionary.
     output_file_dict = {}

--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -229,7 +229,7 @@ def make_output_file_dict(filename,header_data):
         
         Parameters:
         input: filename
-        a path to where the file is located.
+        a path to the input file.
         header_data: dictionary
         information extracted from the image header, needed to configure
         the filename.
@@ -255,9 +255,10 @@ def make_output_file_dict(filename,header_data):
     if instrument == 'WFPC2':
         hardware = instrument.lower()
     else:
-        hardware = instrument + '-' + detector
+        hardware = instrument.lower() + '-' + detector.lower()
 
-    ipsud = filename.split('_')[0] 
+    path, basename = os.path.split(filename)
+    ipsud = basename.split('_')[0] 
 
     # Use string parsing to discern the target(s).
     mtarg = get_mtarg(header_data['targname'])
@@ -276,7 +277,6 @@ def make_output_file_dict(filename,header_data):
     output_file_dict['drizzle_output'] = []
     output_file_dict['png_output'] = []
     output_file_dict['drizzle_weight'] = []
-    path, basename = os.path.split(filename)
     
 
     # CR Rejection outputs.
@@ -284,28 +284,36 @@ def make_output_file_dict(filename,header_data):
     output_file_dict['cr_reject_output'].append(filename) 
     # The actual output:
     filename = '_'.join([front,fits_type]) + '.fits'
+    filename = os.path.join(path,filename)
     output_file_dict['cr_reject_output'].append(filename) 
 
     # Drizzled outputs.
     # Cr rejected products are sci
     filename = '_'.join([front,'sci']) + '.fits'
+    filename = os.path.join(path,filename)
     output_file_dict['drizzle_output'].append(filename)
     # Non cr rejected products are img
     filename = '_'.join([front,'img']) + '.fits'
+    filename = os.path.join(path,filename)
     output_file_dict['drizzle_output'].append(filename)
     # Only a single weight file
     filename = '_'.join([front,'wht']) + '.fits'
+    filename = os.path.join(path,filename)
     output_file_dict['drizzle_weight'].append(filename)
 
     # PNG outputs.
     png = 'png/'
     filename = png + '_'.join([front,'sci']) + '-linear.png'
+    filename = os.path.join(path,filename)
     output_file_dict['png_output'].append(filename)
     filename = png + '_'.join([front,'img']) + '-linear.png'
+    filename = os.path.join(path,filename)
     output_file_dict['png_output'].append(filename)
     filename = png + '_'.join([front,'sci']) + '-log.png'
+    filename = os.path.join(path,filename)
     output_file_dict['png_output'].append(filename)
     filename = png + '_'.join([front,'img']) + '-log.png'
+    filename = os.path.join(path,filename)
     output_file_dict['png_output'].append(filename)
 
     return output_file_dict

--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -387,9 +387,8 @@ def imaging_pipeline(root_filename, output_path = None, cr_reject_switch=True,
         else:
             print 'Running png'
             logging.info("Running png")
-            for filename, weight_file in zip(output_file_dict['drizzle_output'], \
-                    output_file_dict['drizzle_weight']):
-                run_trim(filename, weight_file, output_path,log_switch=True)
+            for filename in output_file_dict['drizzle_output']:
+                run_trim(filename, output_path,log_switch=True)
             print 'Done running png'
             logging.info("Done running png")
     else:

--- a/mtpipeline/imaging/run_astrodrizzle.py
+++ b/mtpipeline/imaging/run_astrodrizzle.py
@@ -64,38 +64,43 @@ def move_files(target, file_list, recopy_switch):
 
 # ------------------------------------------------------------------------------
 
-def rename_files(rootfile, mode, output_path):
+def rename_files(rootfile, output):
     '''
-    Rename all the files that match the root of the filename input 
-    paramater, excluding the input filename itself.
+    Rename all desirable files that match the root of the filename input 
+    paramater, excluding the input filename itself. Remove all other
+    AstroDrizzle outputs.
     '''
-    print 'Renaming Files'
+    print 'Renaming Files:'
     
-    # Build the file list.
     rootfile = os.path.abspath(rootfile)
-    basename = os.path.splitext(rootfile)[0]
-    if '_flt' in basename:
-        basename = basename.replace('_flt','')
-    search = basename + '_sci*'
-    file_list_1 = glob.glob(search)
-    search = basename + '_single*'
-    file_list_2 = glob.glob(search)
-    file_list = file_list_1 + file_list_2
-    
-    # Loop over the files and rename.
-    for filename in file_list:
-        dst = string.split(basename,'/')[-1] + '_' + mode 
-        dst += string.split(filename, basename)[1]
-        if output_path == None:
-            dst = os.path.join(os.path.dirname(rootfile), dst)
-        elif output_path != None:
-            dst = os.path.join(output_path, dst)
-        shutil.copyfile(filename, dst)
+
+    # Remove unwanted AstroDrizzle outputs
+    search = rootfile[:-8] + '*mask*'
+    bad_list = glob.glob(search)
+    for filename in bad_list:
+        print "Removing " ,filename
+        os.remove(filename)
+
+    # Find the wanted files
+    search = rootfile[:-8] + '*single_sci.fits'
+    sci_list = glob.glob(search)
+    search = rootfile[:-8] + '*single_wht.fits'
+    wht_list = glob.glob(search)
+    # Loop over the wanted files and rename.
+    for filename in sci_list:
+        print "Renaming ",filename, " to ",output
+        shutil.copyfile(filename, output)
+        os.remove(filename)
+    for filename in wht_list:
+        output = output.replace('_sci','_wht')
+        output = output.replace('_img','_wht')
+        print "Renaming ",filename, " to ",output
+        shutil.copyfile(filename, output)
         os.remove(filename)
 
 # ------------------------------------------------------------------------------
 
-def run_astrodrizzle(filename, detector, output_path = None):
+def run_astrodrizzle(filename, output, detector):
     '''
     Executes astrodrizzle.AstroDrizzle.
     '''
@@ -107,23 +112,17 @@ def run_astrodrizzle(filename, detector, output_path = None):
         cfg_path = cfg_path.replace('/mtpipeline/imaging/run_astrodrizzle.py',
                                 '/astrodrizzle_cfg/')
 
-    # If other AstroDrizzle outputs are desired, add a cfg file for each
-    # instrument in the lists below, and add the name of the mode to mode_list.
-    mode_list = ['wide']
-    config_sets = {'WFPC2' : ['wfpc2_wideslice.cfg'],
-                   'WFC' : ['acs_wide.cfg'],
-                   'HRC' : ['acs_hrc_wide.cfg'],
-                   'SBC' : ['acs_wide.cfg'],
-                   'UVIS':['wfc3_wide.cfg'],
-                   'IR': ['wfc3_ir_wide.cfg']
+    config_sets = {'WFPC2' : 'wfpc2_wideslice.cfg',
+                   'WFC' : 'acs_wide.cfg',
+                   'HRC' : 'acs_hrc_wide.cfg',
+                   'SBC' : 'acs_wide.cfg',
+                   'UVIS':'wfc3_wide.cfg',
+                   'IR': 'wfc3_ir_wide.cfg'
                   }
 
-    configobj_list = config_sets[detector]
-    for configobj, mode in zip(configobj_list, mode_list):
-        astrodrizzle.AstroDrizzle(
-            input = filename,
-            configobj = os.path.join(cfg_path, configobj))
-        rename_files(filename, mode, output_path)
+    config_file = os.path.join(cfg_path, config_sets[detector])
+    astrodrizzle.AstroDrizzle(input = filename, configobj = config_file)
+    rename_files(filename, output)
             
 # ------------------------------------------------------------------------------
 # The main controller. 

--- a/mtpipeline/imaging/run_astrodrizzle.py
+++ b/mtpipeline/imaging/run_astrodrizzle.py
@@ -89,14 +89,12 @@ def rename_files(rootfile, output):
     # Loop over the wanted files and rename.
     for filename in sci_list:
         print "Renaming ",filename, " to ",output
-        shutil.copyfile(filename, output)
-        os.remove(filename)
+        os.rename(filename,output)
     for filename in wht_list:
         output = output.replace('_sci','_wht')
         output = output.replace('_img','_wht')
         print "Renaming ",filename, " to ",output
-        shutil.copyfile(filename, output)
-        os.remove(filename)
+        os.rename(filename,output)
 
 # ------------------------------------------------------------------------------
 

--- a/mtpipeline/imaging/run_cosmicx.py
+++ b/mtpipeline/imaging/run_cosmicx.py
@@ -183,11 +183,12 @@ def run_cosmicx(filename, output, cosmicx_params, detector):
         HDUlist.writeto(output)
 
     # Create the symbolic link
-    make_c1m_link(os.path.abspath(filename))
+    make_c1m_link(os.path.abspath(filename),
+                  os.path.abspath(output))
 
 # -----------------------------------------------------------------------------
 
-def make_c1m_link(filename):
+def make_c1m_link(filename, output):
     """ Create a link to a c1m.fits that matches the cosmic ray rejected
     naming scheme. This is only done for WFPC2 data (which ends in _c0m.fits)
 
@@ -203,7 +204,7 @@ def make_c1m_link(filename):
 
     if filename[-8:] == 'c0m.fits':
         src = filename.replace('_c0m.fits', '_c1m.fits')
-        dst = src.replace('_c1m.fits', '_cr_c1m.fits')
+        dst = output.replace('_c0m.fits', '_c1m.fits')
         query = os.path.islink(dst)
 
         if query == True:

--- a/mtpipeline/imaging/run_trim.py
+++ b/mtpipeline/imaging/run_trim.py
@@ -322,7 +322,7 @@ def run_trim(filename, output_path, log_switch=True,
         pngc_log = PNGCreator(pngc_linear.data)
 
     pngc_linear.compress()
-    pngc_linear.save_png(make_png_name(output_path, filename, 'linear'))
+    pngc_linear.save_png(make_png_name(output_path, filename, 'linscale'))
 
     # Create Log full Image
     if log_switch:
@@ -331,7 +331,7 @@ def run_trim(filename, output_path, log_switch=True,
         #pngc_log.positive(output = positive_stat)
         pngc_log.log(output = log_stat)
         pngc_log.compress()
-        pngc_log.save_png(make_png_name(output_path, filename, 'log'))
+        pngc_log.save_png(make_png_name(output_path, filename, 'logscale'))
 
     else:
         logger.info('Skipping log pngs.')

--- a/mtpipeline/imaging/run_trim.py
+++ b/mtpipeline/imaging/run_trim.py
@@ -96,7 +96,7 @@ def make_png_name(path, filename, ext):
     Return the name of the png output_array file.
     '''
     png_name = os.path.basename(filename)
-    png_name = os.path.splitext(png_name)[0] + '_' + ext + '.png'
+    png_name = os.path.splitext(png_name)[0] + '-' + ext + '.png'
     png_name = os.path.join(path, png_name)
     return png_name
 
@@ -216,36 +216,6 @@ class PNGCreator(object):
 
         self.data = output_array
 
-    def saturated_clip(self, weight_array, output=False):
-        '''
-        Replace all the pixels that have a weight value of 0 with the local
-        3x3 median. A copy of the image is created so that the values of
-        the replaced pixels don't affect the medians of other pixels as
-        they are replaced. The subarray function is used to generate the
-        subarrays to prevent error at the array edge.
-
-        The indices are set keeping in mind that a[0:2,0:2] returns a 2x2
-        array while a[0:3,0:3] returns a 3x3 array. Both arrays are
-        centered on (1,1).
-        '''
-
-        assert isinstance(weight_array, N.ndarray), 'array must be numpy array'
-        output_array = copy.copy(self.data)
-        saturated_indices = N.where(weight_array == 0)
-        for index in zip(saturated_indices[0], saturated_indices[1]):
-             output_array[index] = N.median(subarray(self.data, index[0] - 1, \
-                index[0] + 2, index[1] - 1, index[1] + 2))
-
-        if output != False:
-            before_after(before_array = self.data,
-                after_array = output_array,
-                before_array_name = 'Input Data',
-                after_array_name = '0-Weight Corrected',
-                output = output,
-                pause = False)
-
-        self.data = output_array
-
     def save_png(self, png_name):
         '''
         Use the Python image library (PIL) to write self.data as a png file.
@@ -306,7 +276,7 @@ def make_subimage_pngs(input_pngc_instance, output_path, filename, suffix):
 
 # -----------------------------------------------------------------------------
 
-def run_trim(filename, weight_file, output_path, log_switch=True,
+def run_trim(filename, output_path, log_switch=True,
         stat_switch=False):
     '''
     The main controller for the png creation. Checks for and creates an
@@ -341,7 +311,6 @@ def run_trim(filename, weight_file, output_path, log_switch=True,
 
     # Get the data.
     data = get_fits_data(filename)
-    weight_data = get_fits_data(weight_file)
 
     # Create Linear full image
     logger.info('Creating linear PNGs')

--- a/scripts/production/run_imaging_pipeline.py
+++ b/scripts/production/run_imaging_pipeline.py
@@ -121,7 +121,7 @@ def run():
     rootfile_list = glob.glob(args_list.filelist)
     rootfile_list = [filename for filename
                      in rootfile_list
-                     if '_cr_' not in filename
+                     if 'hlsp_' not in filename
                      and ('_flt.fits' in filename or '_c0m.fits' in filename)]
     assert rootfile_list != [], 'empty rootfile_list in mtpipeline.py.'
     logging.info("Processing: {} files".format(len(rootfile_list)))

--- a/template_settings.yaml
+++ b/template_settings.yaml
@@ -9,8 +9,11 @@ db_echo: False
 email_switch: False
 contact_email: youremail@domain.com
 
-# File System Settings
+## File System Settings
 logging_path: /path/to/logging
 
-#Number of Cores
+##Number of Cores
 num_cores: 2
+
+##Pipeline version number
+version: '1.0'

--- a/tests/unit_tests/test_imaging_pipeline.py
+++ b/tests/unit_tests/test_imaging_pipeline.py
@@ -8,8 +8,8 @@ expected_output_list = [
                         'cr_reject_output': ['asdfghjkl_c0m.fits', 
                                              'hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_c0m.fits'],
 
-                        'drizzle_output': [ 'hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci.fits',
-                                            'hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img.fits'],
+                        'drizzle_output': [ 'hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img.fits',
+                                            'hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci.fits'],
 
                         'png_output': ['png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci-linear.png',
                                        'png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img-linear.png',
@@ -24,8 +24,8 @@ expected_output_list = [
                         'cr_reject_output': ['asdfghjkl_flt.fits', 
                                              'hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_flt.fits'],
 
-                        'drizzle_output': [ 'hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_sci.fits',
-                                            'hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_img.fits'],
+                        'drizzle_output': [ 'hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_img.fits',
+                                            'hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_sci.fits'],
 
                         'png_output': ['png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_sci-linear.png',
                                        'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_img-linear.png',
@@ -40,8 +40,8 @@ expected_output_list = [
                         'cr_reject_output': ['dir/asdfghjkl_c0m.fits', 
                                              'dir/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_c0m.fits'],
 
-                        'drizzle_output': [ 'dir/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci.fits',
-                                            'dir/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img.fits'],
+                        'drizzle_output': [ 'dir/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img.fits',
+                                            'dir/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci.fits'],
 
                         'png_output': ['dir/png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci-linear.png',
                                        'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img-linear.png',

--- a/tests/unit_tests/test_imaging_pipeline.py
+++ b/tests/unit_tests/test_imaging_pipeline.py
@@ -6,54 +6,54 @@ from mtpipeline.imaging.imaging_pipeline import make_output_file_dict
 expected_output_list = [
                         {'input_file': 'asdfghjkl_c0m.fits',
                         'cr_reject_output': ['asdfghjkl_c0m.fits', 
-                                             'hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_c0m.fits'],
+                                             'hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_c0m.fits'],
 
-                        'drizzle_output': [ 'hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_img.fits',
-                                            'hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_sci.fits'],
+                        'drizzle_output': [ 'hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_img.fits',
+                                            'hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_sci.fits'],
 
-                        'png_output': ['png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_sci-linear.png',
-                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_img-linear.png',
-                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_sci-log.png',
-                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_img-log.png'],
+                        'png_output': ['png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_sci-linscale.png',
+                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_img-linscale.png',
+                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_sci-logscale.png',
+                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_img-logscale.png'],
                         
-                        'drizzle_weight': ['hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_wht.fits']
+                        'drizzle_weight': ['hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_wht.fits']
 
                         },
 
                         {'input_file': 'asdfghjkl_flt.fits',
                         'cr_reject_output': ['asdfghjkl_flt.fits', 
-                                             'hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_F606W_v1-0_flt.fits'],
+                                             'hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_flt.fits'],
 
-                        'drizzle_output': [ 'hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_F606W_v1-0_img.fits',
-                                            'hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_F606W_v1-0_sci.fits'],
+                        'drizzle_output': [ 'hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_img.fits',
+                                            'hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_sci.fits'],
 
-                        'png_output': ['png/hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_F606W_v1-0_sci-linear.png',
-                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_F606W_v1-0_img-linear.png',
-                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_F606W_v1-0_sci-log.png',
-                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_F606W_v1-0_img-log.png'],
+                        'png_output': ['png/hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_sci-linscale.png',
+                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_img-linscale.png',
+                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_sci-logscale.png',
+                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_img-logscale.png'],
                         
-                        'drizzle_weight': ['hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_F606W_v1-0_wht.fits']
+                        'drizzle_weight': ['hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_wht.fits']
 
                         },
 
                         {'input_file': 'dir/asdfghjkl_c0m.fits',
                         'cr_reject_output': ['dir/asdfghjkl_c0m.fits', 
-                                             'dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_c0m.fits'],
+                                             'dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_c0m.fits'],
 
-                        'drizzle_output': [ 'dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_img.fits',
-                                            'dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_sci.fits'],
+                        'drizzle_output': [ 'dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_img.fits',
+                                            'dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_sci.fits'],
 
-                        'png_output': ['dir/png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_sci-linear.png',
-                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_img-linear.png',
-                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_sci-log.png',
-                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_img-log.png'],
+                        'png_output': ['dir/png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_sci-linscale.png',
+                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_img-linscale.png',
+                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_sci-logscale.png',
+                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_img-logscale.png'],
                         
-                        'drizzle_weight': ['dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_wht.fits']
+                        'drizzle_weight': ['dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_wht.fits']
 
                         },
                        ]
 
-# A list of dictionaries the metadata for each fake test file
+# A list of dictionaries of metadata for each fake test file
 metadata_list = [
                     {'instrument': 'WFPC2',
                      'detector' : 'WFPC2',

--- a/tests/unit_tests/test_imaging_pipeline.py
+++ b/tests/unit_tests/test_imaging_pipeline.py
@@ -11,10 +11,10 @@ expected_output_list = [
                         'drizzle_output': [ 'hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci.fits',
                                             'hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img.fits'],
 
-                        'png_output': ['png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img-linear.png',
-                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci-linear.png',
-                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img-log.png',
-                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci-log.png'],
+                        'png_output': ['png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci-linear.png',
+                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img-linear.png',
+                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci-log.png',
+                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img-log.png'],
                         
                         'drizzle_weight': ['hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_wht.fits']
 
@@ -22,15 +22,15 @@ expected_output_list = [
 
                         {'input_file': 'asdfghjkl_flt.fits',
                         'cr_reject_output': ['asdfghjkl_flt.fits', 
-                                             'hlsp_mt_hst_wfc3-uvis-0_flt.fits'],
+                                             'hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_flt.fits'],
 
                         'drizzle_output': [ 'hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_sci.fits',
                                             'hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_img.fits'],
 
-                        'png_output': ['png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_img-linear.png',
-                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_sci-linear.png',
-                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_img-log.png',
-                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_sci-log.png'],
+                        'png_output': ['png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_sci-linear.png',
+                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_img-linear.png',
+                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_sci-log.png',
+                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_img-log.png'],
                         
                         'drizzle_weight': ['hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_wht.fits']
 
@@ -131,7 +131,7 @@ def test_make_output_file_dict():
     for expected_output, metadata in zip(expected_output_list, metadata_list):
     
         output_dict = make_output_file_dict(
-                      expected_output['input_file'],metadata_list)
+                      expected_output['input_file'],metadata)
         expected_keys = expected_output.keys()
         output_keys = output_dict.keys()
 

--- a/tests/unit_tests/test_imaging_pipeline.py
+++ b/tests/unit_tests/test_imaging_pipeline.py
@@ -2,20 +2,21 @@
 
 from mtpipeline.imaging.imaging_pipeline import make_output_file_dict
 
+# A list of different input files and the resulting set of expected outputs.
 expected_output_list = [
                         {'input_file': 'asdfghjkl_c0m.fits',
                         'cr_reject_output': ['asdfghjkl_c0m.fits', 
-                                             'hlsp_mt_hst_wfpc2_asdfghjkl_ceres_F606W_v1-0_c0m.fits'],
+                                             'hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_c0m.fits'],
 
-                        'drizzle_output': [ 'hlsp_mt_hst_wfpc2_asdfghjkl_ceres_F606W_v1-0_sci.fits',
-                                            'hlsp_mt_hst_wfpc2_asdfghjkl_ceres_F606W_v1-0_img.fits'],
+                        'drizzle_output': [ 'hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci.fits',
+                                            'hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img.fits'],
 
-                        'png_output': ['png/hlsp_mt_hst_wfpc2_asdfghjkl_ceres_F606W_v1-0_img-linear.png',
-                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_ceres_F606W_v1-0_sci-linear.png',
-                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_ceres_F606W_v1-0_img-log.png',
-                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_ceres_F606W_v1-0_sci-log.png'],
+                        'png_output': ['png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img-linear.png',
+                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci-linear.png',
+                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img-log.png',
+                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci-log.png'],
                         
-                        'drizzle_weight': ['hlsp_mt_hst_wfpc2_asdfghjkl_ceres_F606W_v1-0_wht.fits']
+                        'drizzle_weight': ['hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_wht.fits']
 
                         },
 
@@ -23,18 +24,35 @@ expected_output_list = [
                         'cr_reject_output': ['asdfghjkl_flt.fits', 
                                              'hlsp_mt_hst_wfc3-uvis-0_flt.fits'],
 
-                        'drizzle_output': [ 'hlsp_mt_hst_wfc3-uvis_asdfghjkl_ceres_F606W_v1-0_sci.fits',
-                                            'hlsp_mt_hst_wfc3-uvis_asdfghjkl_ceres_F606W_v1-0_img.fits'],
+                        'drizzle_output': [ 'hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_sci.fits',
+                                            'hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_img.fits'],
 
-                        'png_output': ['png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_ceres_F606W_v1-0_img-linear.png',
-                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_ceres_F606W_v1-0_sci-linear.png',
-                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_ceres_F606W_v1-0_img-log.png',
-                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_ceres_F606W_v1-0_sci-log.png'],
+                        'png_output': ['png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_img-linear.png',
+                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_sci-linear.png',
+                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_img-log.png',
+                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_sci-log.png'],
                         
-                        'drizzle_weight': ['hlsp_mt_hst_wfc3-uvis_asdfghjkl_ceres_F606W_v1-0_wht.fits']
+                        'drizzle_weight': ['hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_wht.fits']
 
                         },
                        ]
+
+# A list of dictionaries the metadata for each fake test file
+metadata_list = [
+                    {'instrument': 'WFPC2',
+                     'detector' : 'WFPC2',
+                     'readnoise' : None,
+                     'gain' : None,
+                     'targname' : 'mars',
+                     'filtername': 'F606W'},
+
+                    {'instrument': 'wfc3',
+                     'detector' : 'uvis',
+                     'readnoise' : None,
+                     'gain' : None,
+                     'targname' : 'mars',
+                     'filtername': 'F606W'},
+                   ]
                         
 
 def check_output_entry(output_entry,expected_entry):
@@ -108,12 +126,12 @@ def test_make_output_file_dict():
         nothing
     
     """
-    
+
     # Go through each test case (different input filenames):
-    for expected_output in expected_output_list:
+    for expected_output, metadata in zip(expected_output_list, metadata_list):
     
         output_dict = make_output_file_dict(
-                      expected_output['input_file'])
+                      expected_output['input_file'],metadata_list)
         expected_keys = expected_output.keys()
         output_keys = output_dict.keys()
 

--- a/tests/unit_tests/test_imaging_pipeline.py
+++ b/tests/unit_tests/test_imaging_pipeline.py
@@ -3,26 +3,38 @@
 from mtpipeline.imaging.imaging_pipeline import make_output_file_dict
 
 expected_output_list = [
-                        {'input_file': 'u2eu0101t_c0m.fits',
-                        'cr_reject_output': ['u2eu0101t_c0m.fits', 'u2eu0101t_cr_c0m.fits'],
-                        'drizzle_output': ['u2eu0101t_c0m_wide_single_sci.fits',
-                                           'u2eu0101t_cr_c0m_wide_single_sci.fits'],
-                        'png_output': ['png/u2eu0101t_c0m_wide_single_sci_linear.png',
-                                       'png/u2eu0101t_cr_c0m_wide_single_sci_linear.png'],
-                        'drizzle_weight': ['u2eu0101t_c0m_wide_single_wht.fits',
-                                           'u2eu0101t_cr_c0m_wide_single_wht.fits']
-                        },
-                        {'input_file': 'u2eu0101t_flt.fits',
-                        'cr_reject_output': ['u2eu0101t_flt.fits', 'u2eu0101t_cr_flt.fits'],
-                        'drizzle_output': ['u2eu0101t_wide_single_sci.fits',
-                                           'u2eu0101t_cr_wide_single_sci.fits'],
-                        'png_output': ['png/u2eu0101t_wide_single_sci_linear.png',
-                                       'png/u2eu0101t_cr_wide_single_sci_linear.png'],
-                        'drizzle_weight': ['u2eu0101t_wide_single_wht.fits',
-                                           'u2eu0101t_cr_wide_single_wht.fits']
-			            }
-                       ]
+                        {'input_file': 'asdfghjkl_c0m.fits',
+                        'cr_reject_output': ['asdfghjkl_c0m.fits', 
+                                             'hlsp_mt_hst_wfpc2_asdfghjkl_ceres_F606W_v1-0_c0m.fits'],
 
+                        'drizzle_output': [ 'hlsp_mt_hst_wfpc2_asdfghjkl_ceres_F606W_v1-0_sci.fits',
+                                            'hlsp_mt_hst_wfpc2_asdfghjkl_ceres_F606W_v1-0_img.fits'],
+
+                        'png_output': ['png/hlsp_mt_hst_wfpc2_asdfghjkl_ceres_F606W_v1-0_img-linear.png',
+                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_ceres_F606W_v1-0_sci-linear.png',
+                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_ceres_F606W_v1-0_img-log.png',
+                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_ceres_F606W_v1-0_sci-log.png'],
+                        
+                        'drizzle_weight': ['hlsp_mt_hst_wfpc2_asdfghjkl_ceres_F606W_v1-0_wht.fits']
+
+                        },
+
+                        {'input_file': 'asdfghjkl_flt.fits',
+                        'cr_reject_output': ['asdfghjkl_flt.fits', 
+                                             'hlsp_mt_hst_wfc3-uvis-0_flt.fits'],
+
+                        'drizzle_output': [ 'hlsp_mt_hst_wfc3-uvis_asdfghjkl_ceres_F606W_v1-0_sci.fits',
+                                            'hlsp_mt_hst_wfc3-uvis_asdfghjkl_ceres_F606W_v1-0_img.fits'],
+
+                        'png_output': ['png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_ceres_F606W_v1-0_img-linear.png',
+                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_ceres_F606W_v1-0_sci-linear.png',
+                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_ceres_F606W_v1-0_img-log.png',
+                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_ceres_F606W_v1-0_sci-log.png'],
+                        
+                        'drizzle_weight': ['hlsp_mt_hst_wfc3-uvis_asdfghjkl_ceres_F606W_v1-0_wht.fits']
+
+                        },
+                       ]
                         
 
 def check_output_entry(output_entry,expected_entry):

--- a/tests/unit_tests/test_imaging_pipeline.py
+++ b/tests/unit_tests/test_imaging_pipeline.py
@@ -6,49 +6,49 @@ from mtpipeline.imaging.imaging_pipeline import make_output_file_dict
 expected_output_list = [
                         {'input_file': 'asdfghjkl_c0m.fits',
                         'cr_reject_output': ['asdfghjkl_c0m.fits', 
-                                             'hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_c0m.fits'],
+                                             'hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_c0m.fits'],
 
-                        'drizzle_output': [ 'hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img.fits',
-                                            'hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci.fits'],
+                        'drizzle_output': [ 'hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_img.fits',
+                                            'hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_sci.fits'],
 
-                        'png_output': ['png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci-linear.png',
-                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img-linear.png',
-                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci-log.png',
-                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img-log.png'],
+                        'png_output': ['png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_sci-linear.png',
+                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_img-linear.png',
+                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_sci-log.png',
+                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_img-log.png'],
                         
-                        'drizzle_weight': ['hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_wht.fits']
+                        'drizzle_weight': ['hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_wht.fits']
 
                         },
 
                         {'input_file': 'asdfghjkl_flt.fits',
                         'cr_reject_output': ['asdfghjkl_flt.fits', 
-                                             'hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_flt.fits'],
+                                             'hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_F606W_v1-0_flt.fits'],
 
-                        'drizzle_output': [ 'hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_img.fits',
-                                            'hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_sci.fits'],
+                        'drizzle_output': [ 'hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_F606W_v1-0_img.fits',
+                                            'hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_F606W_v1-0_sci.fits'],
 
-                        'png_output': ['png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_sci-linear.png',
-                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_img-linear.png',
-                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_sci-log.png',
-                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_img-log.png'],
+                        'png_output': ['png/hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_F606W_v1-0_sci-linear.png',
+                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_F606W_v1-0_img-linear.png',
+                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_F606W_v1-0_sci-log.png',
+                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_F606W_v1-0_img-log.png'],
                         
-                        'drizzle_weight': ['hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_wht.fits']
+                        'drizzle_weight': ['hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_F606W_v1-0_wht.fits']
 
                         },
 
                         {'input_file': 'dir/asdfghjkl_c0m.fits',
                         'cr_reject_output': ['dir/asdfghjkl_c0m.fits', 
-                                             'dir/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_c0m.fits'],
+                                             'dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_c0m.fits'],
 
-                        'drizzle_output': [ 'dir/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img.fits',
-                                            'dir/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci.fits'],
+                        'drizzle_output': [ 'dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_img.fits',
+                                            'dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_sci.fits'],
 
-                        'png_output': ['dir/png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci-linear.png',
-                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img-linear.png',
-                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci-log.png',
-                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img-log.png'],
+                        'png_output': ['dir/png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_sci-linear.png',
+                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_img-linear.png',
+                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_sci-log.png',
+                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_img-log.png'],
                         
-                        'drizzle_weight': ['dir/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_wht.fits']
+                        'drizzle_weight': ['dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_F606W_v1-0_wht.fits']
 
                         },
                        ]

--- a/tests/unit_tests/test_imaging_pipeline.py
+++ b/tests/unit_tests/test_imaging_pipeline.py
@@ -35,6 +35,22 @@ expected_output_list = [
                         'drizzle_weight': ['hlsp_mt_hst_wfc3-uvis_asdfghjkl_mars_F606W_v1-0_wht.fits']
 
                         },
+
+                        {'input_file': 'dir/asdfghjkl_c0m.fits',
+                        'cr_reject_output': ['dir/asdfghjkl_c0m.fits', 
+                                             'dir/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_c0m.fits'],
+
+                        'drizzle_output': [ 'dir/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci.fits',
+                                            'dir/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img.fits'],
+
+                        'png_output': ['dir/png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci-linear.png',
+                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img-linear.png',
+                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_sci-log.png',
+                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_img-log.png'],
+                        
+                        'drizzle_weight': ['dir/hlsp_mt_hst_wfpc2_asdfghjkl_mars_F606W_v1-0_wht.fits']
+
+                        },
                        ]
 
 # A list of dictionaries the metadata for each fake test file
@@ -46,8 +62,15 @@ metadata_list = [
                      'targname' : 'mars',
                      'filtername': 'F606W'},
 
-                    {'instrument': 'wfc3',
-                     'detector' : 'uvis',
+                    {'instrument': 'WFC3',
+                     'detector' : 'UVIS',
+                     'readnoise' : None,
+                     'gain' : None,
+                     'targname' : 'mars',
+                     'filtername': 'F606W'},
+
+                    {'instrument': 'WFPC2',
+                     'detector' : 'WFPC2',
                      'readnoise' : None,
                      'gain' : None,
                      'targname' : 'mars',


### PR DESCRIPTION
This branch rewrites the pipeline's filename handling, in order to adopt the requested MAST conventions. The development process for this branch, as well as the new convention, is documented in Ticket #143.

The major changes to the code are as follows:
- filenames now require metadata from the input image header.
- a new function that will attempt to convert the targname entry in the image header to a name known by JPL ephemeris. If no match is found, the targname is used, to a maximum of 20 characters.\
- The output filename dictionary is used more than ever in determining the names of the actual output files. Most importantly, there is now a dependence on the order of names within the lists of the output dictionary. See [here](https://github.com/STScI-Citizen-Science/MTPipeline/issues/143#issuecomment-51701003) for more details.
