### PR TITLE
Remove the png folder from pipeline outputs

### DIFF
--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -306,17 +306,16 @@ def make_output_file_dict(filename,header_data):
     output_file_dict['drizzle_weight'].append(filename)
 
     # PNG outputs.
-    png = 'png/'
-    filename = png + '_'.join([front,'sci']) + '-linscale.png'
+    filename = '_'.join([front,'sci']) + '-linscale.png'
     filename = os.path.join(path,filename)
     output_file_dict['png_output'].append(filename)
-    filename = png + '_'.join([front,'img']) + '-linscale.png'
+    filename = '_'.join([front,'img']) + '-linscale.png'
     filename = os.path.join(path,filename)
     output_file_dict['png_output'].append(filename)
-    filename = png + '_'.join([front,'sci']) + '-logscale.png'
+    filename = '_'.join([front,'sci']) + '-logscale.png'
     filename = os.path.join(path,filename)
     output_file_dict['png_output'].append(filename)
-    filename = png + '_'.join([front,'img']) + '-logscale.png'
+    filename = '_'.join([front,'img']) + '-logscale.png'
     filename = os.path.join(path,filename)
     output_file_dict['png_output'].append(filename)
 

--- a/mtpipeline/imaging/run_astrodrizzle.py
+++ b/mtpipeline/imaging/run_astrodrizzle.py
@@ -70,7 +70,7 @@ def rename_files(rootfile, output):
     paramater, excluding the input filename itself. Remove all other
     AstroDrizzle outputs.
     '''
-    print 'Renaming Files:'
+    print 'Renaming and removing files:'
     
     rootfile = os.path.abspath(rootfile)
 

--- a/mtpipeline/imaging/run_trim.py
+++ b/mtpipeline/imaging/run_trim.py
@@ -288,10 +288,9 @@ def run_trim(filename, output_path, log_switch=True,
     astrodrizzle_mode = filename.split('_')[-3]
     logger.info('astrodrizzle mode: {0}'.format(astrodrizzle_mode))
 
-    # Define a default output folder
     # Make the output folder if it doesn't exist.
     if output_path == None:
-        output_path = os.path.join(os.path.dirname(filename), 'png')
+        output_path = os.path.dirname(filename) 
     test = os.access(output_path, os.F_OK)
     if test == False:
         os.mkdir(output_path)

--- a/tests/unit_tests/test_imaging_pipeline.py
+++ b/tests/unit_tests/test_imaging_pipeline.py
@@ -11,10 +11,10 @@ expected_output_list = [
                         'drizzle_output': [ 'hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_img.fits',
                                             'hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_sci.fits'],
 
-                        'png_output': ['png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_sci-linscale.png',
-                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_img-linscale.png',
-                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_sci-logscale.png',
-                                       'png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_img-logscale.png'],
+                        'png_output': ['hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_sci-linscale.png',
+                                       'hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_img-linscale.png',
+                                       'hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_sci-logscale.png',
+                                       'hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_img-logscale.png'],
                         
                         'drizzle_weight': ['hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_wht.fits']
 
@@ -27,10 +27,10 @@ expected_output_list = [
                         'drizzle_output': [ 'hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_img.fits',
                                             'hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_sci.fits'],
 
-                        'png_output': ['png/hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_sci-linscale.png',
-                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_img-linscale.png',
-                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_sci-logscale.png',
-                                       'png/hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_img-logscale.png'],
+                        'png_output': ['hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_sci-linscale.png',
+                                       'hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_img-linscale.png',
+                                       'hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_sci-logscale.png',
+                                       'hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_img-logscale.png'],
                         
                         'drizzle_weight': ['hlsp_mt_hst_wfc3-uvis_asdfghjkl-mars_f606w_v1-0_wht.fits']
 
@@ -43,10 +43,10 @@ expected_output_list = [
                         'drizzle_output': [ 'dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_img.fits',
                                             'dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_sci.fits'],
 
-                        'png_output': ['dir/png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_sci-linscale.png',
-                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_img-linscale.png',
-                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_sci-logscale.png',
-                                       'dir/png/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_img-logscale.png'],
+                        'png_output': ['dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_sci-linscale.png',
+                                       'dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_img-linscale.png',
+                                       'dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_sci-logscale.png',
+                                       'dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_img-logscale.png'],
                         
                         'drizzle_weight': ['dir/hlsp_mt_hst_wfpc2_asdfghjkl-mars_f606w_v1-0_wht.fits']
 


### PR DESCRIPTION
This branch no longer creates a separate `mtpipeline_outputs/wfpc2/1111_proj/png' folder for the png outputs. Rather, the png outputs are alongside the fits outputs, as requested by MAST.
