### PR TITLE
Inserting DATE-OBS keyword

### DIFF
--- a/mtpipeline/imaging/imaging_pipeline.py
+++ b/mtpipeline/imaging/imaging_pipeline.py
@@ -56,8 +56,8 @@ def get_metadata(filename):
         
     Returns:
         header_data: dict 
-            Has keys , 'detector','readnoise', and 'gain', 'targname'
-                and , 'filtername'
+            Has keys , 'detector','readnoise', and 'gain', 'targname',
+                'filtername', and 'dateobs'
             Possible 'instrument' values: 'WFPC2', 'WFC3', 'ACS' 
             Possible 'detector' values: 
                 'WFPC2' for WFPC2 (not technically correct, as WFPC2 FITS
@@ -72,6 +72,8 @@ def get_metadata(filename):
     with fits.open(filename, mode='readonly') as HDUlist:
 
         mainHDU = HDUlist[0]
+
+        dateobs = mainHDU.header['date-obs']
         instrument = mainHDU.header['instrume']
         
         # Because WFPC2 has no 'detector' keyword:
@@ -123,7 +125,8 @@ def get_metadata(filename):
                    'readnoise' : readnoise,
                    'gain' : gain,
                    'targname' : targname,
-                   'filtername' : filtername}
+                   'filtername' : filtername,
+                   'dateobs' : dateobs}
 
     return header_data
 
@@ -334,6 +337,7 @@ def imaging_pipeline(root_filename, output_path = None, cr_reject_switch=True,
     # Get information from the header
     header_data = get_metadata(root_filename)
     detector = header_data['detector']
+    dateobs = header_data['dateobs']
 
     # Generate the output filenames 
     filename = os.path.abspath(root_filename) 
@@ -375,7 +379,7 @@ def imaging_pipeline(root_filename, output_path = None, cr_reject_switch=True,
             for filename, output in zip(output_file_dict['cr_reject_output'],
                                         output_file_dict['drizzle_output']):
                 updatewcs.updatewcs(filename)
-                run_astrodrizzle(filename, output, detector)
+                run_astrodrizzle(filename, output, detector, dateobs)
             print 'Done running astrodrizzle'
             logging.info("Done running astrodrizzle")
     else:

--- a/mtpipeline/imaging/run_astrodrizzle.py
+++ b/mtpipeline/imaging/run_astrodrizzle.py
@@ -65,13 +65,11 @@ def insert_dateobs(output, dateobs):
         The AstroDrizzle output file, edited to include DATE-OBS.
     """
 
-    with fits.open(output, mode='readonly') as HDUlist:
-    
-        header = HDUlist[0].header
-        header.append('date-obs', useblanks = True)
-        header['date-obs'] = dateobs
-
-        HDUlist.writeto(output,clobber='True')
+    # Since we are changing only a single keyword, using the convenience
+    # function is permissible.
+    fits.setval(filename = output,
+                keyword = 'date-obs',
+                value = dateobs)
 
 # ------------------------------------------------------------------------------
     
@@ -153,7 +151,11 @@ def run_astrodrizzle(filename, output, detector, dateobs):
     config_file = os.path.join(cfg_path, config_sets[detector])
     astrodrizzle.AstroDrizzle(input = filename, configobj = config_file)
     rename_files(filename, output)
-    insert_dateobs(output, dateobs)
+    
+    # If the iamge is from ACS or WFC3, we need to add the DATE-OBS keyword
+    # back in.
+    if detector != 'WFPC2':
+        insert_dateobs(output, dateobs)
             
 # ------------------------------------------------------------------------------
 # The main controller. 

--- a/mtpipeline/imaging/run_astrodrizzle.py
+++ b/mtpipeline/imaging/run_astrodrizzle.py
@@ -151,11 +151,7 @@ def run_astrodrizzle(filename, output, detector, dateobs):
     config_file = os.path.join(cfg_path, config_sets[detector])
     astrodrizzle.AstroDrizzle(input = filename, configobj = config_file)
     rename_files(filename, output)
-    
-    # If the iamge is from ACS or WFC3, we need to add the DATE-OBS keyword
-    # back in.
-    if detector != 'WFPC2':
-        insert_dateobs(output, dateobs)
+    insert_dateobs(output, dateobs)
             
 # ------------------------------------------------------------------------------
 # The main controller. 

--- a/mtpipeline/imaging/run_astrodrizzle.py
+++ b/mtpipeline/imaging/run_astrodrizzle.py
@@ -4,6 +4,7 @@ A script to run Astrodrizzle.
 '''
 import argparse
 from drizzlepac import astrodrizzle
+from astropy.io import fits
 import glob
 import inspect
 import os
@@ -44,6 +45,35 @@ def get_file_list(target):
     return file_list
     
 # ------------------------------------------------------------------------------
+
+def insert_dateobs(output, dateobs):
+    """ Put the DATE-OBS keyword back into the AstroDrizzle outputs.
+    AstroDrizzle removes this keyword, and it is needed for the database and
+    ephemeris later. 
+
+    Parameters: 
+        output: string
+                The renamed AstroDrizzle output the DATE-OBS keyword needs to be
+                put back into.
+        dateobs: string
+                 The value of the dateobs keyword from the original _flt or _c0m
+                 file.
+
+    Returns: nothing
+
+    Outputs:
+        The AstroDrizzle output file, edited to include DATE-OBS.
+    """
+
+    with fits.open(output, mode='readonly') as HDUlist:
+    
+        header = HDUlist[0].header
+        header.append('date-obs', useblanks = True)
+        header['date-obs'] = dateobs
+
+        HDUlist.writeto(output,clobber='True')
+
+# ------------------------------------------------------------------------------
     
 def move_files(target, file_list, recopy_switch):
     '''
@@ -77,6 +107,8 @@ def rename_files(rootfile, output):
     # Remove unwanted AstroDrizzle outputs
     search = rootfile[:-8] + '*mask*'
     bad_list = glob.glob(search)
+    search = rootfile[:-8] + '*c0m_d2im*'
+    bad_list = bad_list + glob.glob(search)
     for filename in bad_list:
         print "Removing " ,filename
         os.remove(filename)
@@ -98,7 +130,7 @@ def rename_files(rootfile, output):
 
 # ------------------------------------------------------------------------------
 
-def run_astrodrizzle(filename, output, detector):
+def run_astrodrizzle(filename, output, detector, dateobs):
     '''
     Executes astrodrizzle.AstroDrizzle.
     '''
@@ -121,6 +153,7 @@ def run_astrodrizzle(filename, output, detector):
     config_file = os.path.join(cfg_path, config_sets[detector])
     astrodrizzle.AstroDrizzle(input = filename, configobj = config_file)
     rename_files(filename, output)
+    insert_dateobs(output, dateobs)
             
 # ------------------------------------------------------------------------------
 # The main controller. 


### PR DESCRIPTION
This branch adds the function `insert_dateobs()` to `run_astrodrizzle.py`. AstroDrizzle has the unfortunate habit of removing the DATE-OBS keyword from WFC3 and ACS files (curiously, it doesn't do this for WFPC2), and this function reinserts the keyword using the header information from the original input file.

It also has `run_astrodrizzle()` remove unwanted `_d2im.fits` AstroDrizzle WFPC2 outputs, keeping our output archive nice and clean. 

Ticket #154 is the original ticket for this branch.
